### PR TITLE
Fix typo on energy discovery message

### DIFF
--- a/digitalstrom_mqtt/mqtt_homeassistant.go
+++ b/digitalstrom_mqtt/mqtt_homeassistant.go
@@ -281,7 +281,7 @@ func (hass *HomeAssistantMqtt) circuitToHomeAssistantDiscoveryMessage(circuit di
 	// `value_template` field to make the conversion from Ws reported in the
 	// MQTT topic, to kWh which is the default unit of measurement of energy in
 	// Home Assistant.
-	energyNodeId := "power"
+	energyNodeId := "energy"
 	energyTopic := hass.discoveryTopic(Sensor, circuit.Dsid, energyNodeId)
 	energyMessage := map[string]interface{}{
 		"device":            deviceConfig,


### PR DESCRIPTION
This was overwriting the current power discovery message with the energy one. This would require a new release.