### PR TITLE
Update retain configuration for HomeAssistant discovery messages.

### DIFF
--- a/digitalstrom_mqtt/mqtt.go
+++ b/digitalstrom_mqtt/mqtt.go
@@ -128,7 +128,7 @@ func (dm *DigitalstromMqtt) ListenForCircuitValues(changes chan digitalstrom.Cir
 func (dm *DigitalstromMqtt) publishServerStatus(message string) {
 	topic := dm.getStatusTopic()
 	log.Info().Str("status", message).Str("topic", topic).Msg("Updating server status topic")
-	dm.client.Publish(topic, 0, dm.config.Retain, message)
+	dm.client.Publish(topic, 0, true, message)
 }
 
 func (dm *DigitalstromMqtt) publishSceneEvent(sceneEvent digitalstrom.SceneEvent) {

--- a/digitalstrom_mqtt/mqtt_homeassistant.go
+++ b/digitalstrom_mqtt/mqtt_homeassistant.go
@@ -37,7 +37,7 @@ func (hass *HomeAssistantMqtt) publishDiscoveryMessages() {
 		messages, err := hass.deviceToHomeAssistantDiscoveryMessage(device)
 		if utils.CheckNoErrorAndPrint(err) {
 			for _, discovery_message := range messages {
-				hass.mqtt.client.Publish(discovery_message.topic, 0, hass.config.Retain, discovery_message.message)
+				hass.mqtt.client.Publish(discovery_message.topic, 0, true, discovery_message.message)
 			}
 		}
 	}
@@ -45,7 +45,7 @@ func (hass *HomeAssistantMqtt) publishDiscoveryMessages() {
 		messages, err := hass.circuitToHomeAssistantDiscoveryMessage(circuit)
 		if utils.CheckNoErrorAndPrint(err) {
 			for _, discovery_message := range messages {
-				hass.mqtt.client.Publish(discovery_message.topic, 0, hass.config.Retain, discovery_message.message)
+				hass.mqtt.client.Publish(discovery_message.topic, 0, true, discovery_message.message)
 			}
 		}
 	}
@@ -100,7 +100,6 @@ func (hass *HomeAssistantMqtt) deviceToHomeAssistantDiscoveryMessage(device digi
 				device.Name,
 				hass.config.RemoveRegexpFromName),
 			"unique_id":         device.Dsid + "_" + nodeId,
-			"retain":            hass.config.Retain,
 			"availability":      availability,
 			"availability_mode": "all",
 			"command_topic": hass.mqtt.getTopic(
@@ -169,7 +168,6 @@ func (hass *HomeAssistantMqtt) deviceToHomeAssistantDiscoveryMessage(device digi
 				hass.config.RemoveRegexpFromName),
 			"unique_id":         device.Dsid + "_" + nodeId,
 			"device_class":      "blind",
-			"retain":            hass.config.Retain,
 			"availability":      availability,
 			"availability_mode": "all",
 			"state_topic": hass.mqtt.getTopic(
@@ -262,7 +260,6 @@ func (hass *HomeAssistantMqtt) circuitToHomeAssistantDiscoveryMessage(circuit di
 		"device":            deviceConfig,
 		"name":              "Power " + circuit.Name,
 		"unique_id":         circuit.Dsid + "_" + powerNodeId,
-		"retain":            hass.config.Retain,
 		"availability":      availability,
 		"availability_mode": "all",
 		"state_topic": hass.mqtt.getTopic(
@@ -287,7 +284,6 @@ func (hass *HomeAssistantMqtt) circuitToHomeAssistantDiscoveryMessage(circuit di
 		"device":            deviceConfig,
 		"name":              "Energy " + circuit.Name,
 		"unique_id":         circuit.Dsid + "_" + energyNodeId,
-		"retain":            hass.config.Retain,
 		"availability":      availability,
 		"availability_mode": "all",
 		"state_topic": hass.mqtt.getTopic(


### PR DESCRIPTION
This change tries to fix in cases when the Home Assistant instance gets restarted while digitalstrom-mqtt is running. The server availability and discovery config messages are recommended to always be sent with retain `true` so HASS can recover the config after restarts.

Also the discovery messages had the option retain set for the HASS config which meant we were telling HASS to send the command messages with retain, which is not recommended, as restartint digitalstrom-mqtt could lead to out of sync state and start actinioning devices (e.g. covers) after restarting it (this was common in my case).

Now the retain flag of the config is used for the state messages published by digitalstrom-mqtt and nothing else. The rest of configurations regarding HASS use the default recommended values.