### PR TITLE
[codex] Add Home Assistant binary sensor discovery config

### DIFF
--- a/pkg/homeassistant/config.go
+++ b/pkg/homeassistant/config.go
@@ -126,6 +126,18 @@ type SensorConfig struct {
 	ValueTemplate     string `json:"value_template,omitempty"`
 }
 
+// Binary sensor configuration:
+// https://www.home-assistant.io/integrations/binary_sensor.mqtt/
+type BinarySensorConfig struct {
+	BaseConfig
+	StateTopic    string `json:"state_topic,omitempty"`
+	DeviceClass   string `json:"device_class,omitempty"`
+	PayloadOn     string `json:"payload_on,omitempty"`
+	PayloadOff    string `json:"payload_off,omitempty"`
+	Icon          string `json:"icon,omitempty"`
+	ValueTemplate string `json:"value_template,omitempty"`
+}
+
 // Scene configuration:
 // https://www.home-assistant.io/integrations/scene.mqtt/
 type SceneConfig struct {

--- a/pkg/homeassistant/config_test.go
+++ b/pkg/homeassistant/config_test.go
@@ -1,0 +1,47 @@
+package homeassistant
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBinarySensorConfig(t *testing.T) {
+	config := BinarySensorConfig{
+		BaseConfig: BaseConfig{
+			Name:     "motion",
+			UniqueId: "device_motion",
+		},
+		StateTopic:    "digitalstrom/motion/state",
+		DeviceClass:   "motion",
+		PayloadOn:     "ON",
+		PayloadOff:    "OFF",
+		Icon:          "mdi:motion-sensor",
+		ValueTemplate: "{{ value_json.state }}",
+	}
+
+	payload, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("Expected binary sensor config to marshal: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(payload, &result); err != nil {
+		t.Fatalf("Expected binary sensor config to unmarshal: %v", err)
+	}
+
+	expectEqual(t, result["state_topic"], "digitalstrom/motion/state")
+	expectEqual(t, result["device_class"], "motion")
+	expectEqual(t, result["payload_on"], "ON")
+	expectEqual(t, result["payload_off"], "OFF")
+	expectEqual(t, result["icon"], "mdi:motion-sensor")
+	expectEqual(t, result["value_template"], "{{ value_json.state }}")
+	expectEqual(t, string(BinarySensor), "binary_sensor")
+}
+
+func expectEqual(t *testing.T, got interface{}, want interface{}) {
+	t.Helper()
+
+	if want != got {
+		t.Errorf("Expected='%v' but got '%v'", want, got)
+	}
+}

--- a/pkg/homeassistant/discovery.go
+++ b/pkg/homeassistant/discovery.go
@@ -14,6 +14,7 @@ type Domain string
 
 const (
 	Sensor           Domain = "sensor"
+	BinarySensor     Domain = "binary_sensor"
 	Light            Domain = "light"
 	DeviceAutomation Domain = "device_automation"
 	Cover            Domain = "cover"


### PR DESCRIPTION
## Summary

- Add Home Assistant binary_sensor discovery support.
- Add BinarySensorConfig with state topic, payload, device class, icon and value_template fields.
- Add a focused unit test for the generated discovery JSON.

## Validation

- gofmt
- go test -timeout 2m -count=1 ./...

This is a small preparatory change for exposing Digitalstrom states as Home Assistant binary sensors without changing existing MQTT topics or configuration behavior.
