### PR TITLE
Fix health server shutdown after long runtimes

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -24,10 +24,7 @@ type health struct {
 	mqttClient mqtt.Client
 	health     *healthgo.Health
 
-	server        *http.Server
-	serverCtx     context.Context
-	serverStopCtx context.CancelFunc
-	shutdownCtx   context.Context
+	server *http.Server
 }
 
 func NewHealth(config config.HealthCheckConfig, mqttClient mqtt.Client) Health {
@@ -65,8 +62,6 @@ func NewHealth(config config.HealthCheckConfig, mqttClient mqtt.Client) Health {
 func (h *health) Start() error {
 	listenAddr := fmt.Sprintf("0.0.0.0:%d", h.config.Port)
 	h.server = &http.Server{Addr: listenAddr, Handler: h.service()}
-	h.serverCtx, h.serverStopCtx = context.WithCancel(context.Background())
-	h.shutdownCtx, _ = context.WithTimeout(h.serverCtx, 30*time.Second)
 	go func() {
 		log.Info().Msgf("Starting health check server on %s", listenAddr)
 		err := h.server.ListenAndServe()
@@ -78,13 +73,18 @@ func (h *health) Start() error {
 }
 
 func (h *health) Stop() error {
-	err := h.server.Shutdown(h.shutdownCtx)
+	err := shutdownHTTPServer(h.server, 30*time.Second)
 	if err != nil {
 		return err
 	}
-	h.serverStopCtx()
 	log.Info().Msg("Health check server stopped")
 	return nil
+}
+
+func shutdownHTTPServer(server *http.Server, timeout time.Duration) error {
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return server.Shutdown(shutdownCtx)
 }
 
 func (h *health) service() http.Handler {

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -1,0 +1,74 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestShutdownHTTPServerStartsFreshTimeout(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	requestDone := make(chan error, 1)
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseRequest) })
+	}
+	t.Cleanup(release)
+
+	server := &http.Server{Handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+	})}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer server.Close()
+
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			requestDone <- err
+		}
+	}()
+	go func() {
+		response, err := http.Get("http://" + listener.Addr().String())
+		if response != nil {
+			response.Body.Close()
+		}
+		requestDone <- err
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("request did not reach health server")
+	}
+
+	timeout := 40 * time.Millisecond
+	time.Sleep(2 * timeout)
+	shutdownStarted := time.Now()
+	err = shutdownHTTPServer(server, timeout)
+	elapsed := time.Since(shutdownStarted)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected shutdown timeout, got %v", err)
+	}
+	if elapsed < timeout/2 {
+		t.Fatalf("shutdown reused an expired context: elapsed %s, timeout %s", elapsed, timeout)
+	}
+
+	release()
+	select {
+	case err := <-requestDone:
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("request did not finish")
+	}
+}


### PR DESCRIPTION
## Summary

- create the HTTP shutdown timeout when `Stop()` is called
- cancel the timeout context after shutdown
- remove the context created during server startup
- add a regression test for shutdown after the original timeout duration has passed
- guarantee that the test releases its blocked request during cleanup

## Problem

The current shutdown context is created in `Start()` with a 30-second timeout. It therefore expires 30 seconds after the process starts, rather than 30 seconds after shutdown begins.

For a normally long-running process, `http.Server.Shutdown()` receives an already expired context and graceful shutdown can fail immediately.

This change creates a fresh timeout context when shutdown starts. It does not change configuration or the public API.

## Testing

- `go test -timeout 2m -count=20 ./pkg/health`
- `go test -race -timeout 5m ./...`
- `go test -timeout 2m ./...`
- `go vet ./...`
- `go build ./...`

Developed with assistance from OpenAI Codex.