### PR TITLE
Add dS-Weather sensors from apartment status

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ digitalstrom/meterings/chambres/consumptionW/state
 digitalstrom/meterings/chambres/energyWs/state
 ```
 
+### dS-Weather
+
+```
+digitalstrom/weather_station_sensors/DEVICE_NAME/temperature/state
+digitalstrom/weather_station_sensors/DEVICE_NAME/illuminance/state
+digitalstrom/weather_station_sensors/DEVICE_NAME/wind_speed_10min_average/state
+digitalstrom/weather_station_sensors/DEVICE_NAME/wind_gust/state
+digitalstrom/weather_station_sensors/DEVICE_NAME/rain/state
+```
+
 ## Tested devices
 
 digitalSTROM-MQTT was tested successfully with these devices:
@@ -193,6 +203,7 @@ digitalSTROM-MQTT was tested successfully with these devices:
 * GR-KL210
 * GR-KL220
 * GN-KM200 (see [#21](https://github.com/gaetancollaud/digitalstrom-mqtt/issues/21))
+* dS Ready Theben weather station (dS-Weather)
 
 Some devices are known to have issues or limitations:
 

--- a/README.md
+++ b/README.md
@@ -179,12 +179,14 @@ digitalstrom/meterings/chambres/energyWs/state
 
 ### dS-Weather
 
+The dSS apartment status exposes weather measurements as one apartment-wide source, including when multiple weather stations are configured.
+
 ```
-digitalstrom/weather_station_sensors/DEVICE_NAME/temperature/state
-digitalstrom/weather_station_sensors/DEVICE_NAME/illuminance/state
-digitalstrom/weather_station_sensors/DEVICE_NAME/wind_speed_10min_average/state
-digitalstrom/weather_station_sensors/DEVICE_NAME/wind_gust/state
-digitalstrom/weather_station_sensors/DEVICE_NAME/rain/state
+digitalstrom/weather_station_sensors/dS-Weather/temperature/state
+digitalstrom/weather_station_sensors/dS-Weather/illuminance/state
+digitalstrom/weather_station_sensors/dS-Weather/wind_speed_10min_average/state
+digitalstrom/weather_station_sensors/dS-Weather/wind_gust/state
+digitalstrom/weather_station_sensors/dS-Weather/rain/state
 ```
 
 ## Tested devices
@@ -203,7 +205,7 @@ digitalSTROM-MQTT was tested successfully with these devices:
 * GR-KL210
 * GR-KL220
 * GN-KM200 (see [#21](https://github.com/gaetancollaud/digitalstrom-mqtt/issues/21))
-* dS Ready Theben weather station (dS-Weather)
+* dS-Weather (tested with the Theben version)
 
 Some devices are known to have issues or limitations:
 

--- a/pkg/controller/modules/weather.go
+++ b/pkg/controller/modules/weather.go
@@ -3,6 +3,7 @@ package modules
 import (
 	"fmt"
 	"path"
+	"reflect"
 	"strings"
 
 	"github.com/gaetancollaud/digitalstrom-mqtt/pkg/config"
@@ -15,6 +16,8 @@ import (
 const (
 	weatherModuleID       = "weather"
 	weatherStationSensors = "weather_station_sensors"
+	weatherSourceName     = "dS-Weather"
+	weatherSourceIDPrefix = "apartment-weather"
 	weatherTemperature    = "temperature"
 	weatherIlluminance    = "illuminance"
 	weatherWindSpeed      = "wind_speed_10min_average"
@@ -28,28 +31,29 @@ type WeatherModule struct {
 	mqttClient          mqtt.Client
 	dsRegistry          digitalstrom.Registry
 	normalizeDeviceName bool
-	weatherStation      *digitalstrom.Device
+	weatherSourceID     string
 	subscribed          bool
 }
 
 func (c *WeatherModule) Start() error {
-	station, err := c.findWeatherStation()
+	stationCount, err := c.countWeatherStations()
 	if err != nil {
 		return err
 	}
-	if station == nil {
+	if stationCount == 0 {
 		log.Debug().Msg("No dS-Weather station found. Weather module disabled.")
 		return nil
 	}
-	c.weatherStation = station
-	log.Debug().
-		Str("device", station.Attributes.Name).
-		Msg("Weather module enabled.")
 
 	status, err := c.dsRegistry.GetApartmentStatus()
 	if err != nil {
 		return fmt.Errorf("error getting apartment weather status: %w", err)
 	}
+	c.weatherSourceID = weatherDeviceID(status)
+	log.Debug().
+		Int("weather_stations", stationCount).
+		Str("weather_source", c.weatherSourceID).
+		Msg("Weather module enabled with apartment-wide weather data.")
 	if err := c.publishWeatherStatus(status); err != nil {
 		return err
 	}
@@ -75,26 +79,26 @@ func (c *WeatherModule) Stop() error {
 	return c.dsRegistry.ApartmentStatusChangeUnsubscribe(weatherModuleID)
 }
 
-func (c *WeatherModule) findWeatherStation() (*digitalstrom.Device, error) {
+func (c *WeatherModule) countWeatherStations() (int, error) {
 	devices, err := c.dsRegistry.GetDevices()
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
+	stationCount := 0
 	for _, device := range devices {
 		functionBlock, err := c.dsRegistry.GetFunctionBlockForDevice(device.DeviceId)
 		if err != nil {
 			continue
 		}
 		if strings.EqualFold(functionBlock.Attributes.TechnicalName, "Weather") {
-			station := device
-			return &station, nil
+			stationCount++
 		}
 	}
-	return nil, nil
+	return stationCount, nil
 }
 
 func (c *WeatherModule) publishWeatherStatus(status *digitalstrom.ApartmentStatus) error {
-	if status == nil || c.weatherStation == nil {
+	if status == nil || c.weatherSourceID == "" {
 		return nil
 	}
 	measurements := status.Attributes.Measurements
@@ -129,34 +133,40 @@ func (c *WeatherModule) publishWeatherStatus(status *digitalstrom.ApartmentStatu
 }
 
 func weatherStatusEqual(oldStatus *digitalstrom.ApartmentStatus, newStatus *digitalstrom.ApartmentStatus) bool {
-	if oldStatus == nil || newStatus == nil {
-		return oldStatus == newStatus
-	}
-	oldMeasurements := oldStatus.Attributes.Measurements
-	newMeasurements := newStatus.Attributes.Measurements
-	return equalFloat(oldMeasurements.Temperature, newMeasurements.Temperature) &&
-		equalFloat(oldMeasurements.Brightness, newMeasurements.Brightness) &&
-		equalFloat(oldMeasurements.WindSpeed, newMeasurements.WindSpeed) &&
-		equalFloat(oldMeasurements.WindGust, newMeasurements.WindGust) &&
-		equalBool(oldStatus.Attributes.Weather.Rain, newStatus.Attributes.Weather.Rain)
+	return reflect.DeepEqual(weatherValues(oldStatus), weatherValues(newStatus))
 }
 
-func equalFloat(left *float64, right *float64) bool {
-	if left == nil || right == nil {
-		return left == right
-	}
-	return *left == *right
+type apartmentWeatherValues struct {
+	temperature *float64
+	brightness  *float64
+	windSpeed   *float64
+	windGust    *float64
+	rain        *bool
 }
 
-func equalBool(left *bool, right *bool) bool {
-	if left == nil || right == nil {
-		return left == right
+func weatherValues(status *digitalstrom.ApartmentStatus) *apartmentWeatherValues {
+	if status == nil {
+		return nil
 	}
-	return *left == *right
+	measurements := status.Attributes.Measurements
+	return &apartmentWeatherValues{
+		temperature: measurements.Temperature,
+		brightness:  measurements.Brightness,
+		windSpeed:   measurements.WindSpeed,
+		windGust:    measurements.WindGust,
+		rain:        status.Attributes.Weather.Rain,
+	}
+}
+
+func weatherDeviceID(status *digitalstrom.ApartmentStatus) string {
+	if status == nil || status.ApartmentId == "" {
+		return weatherSourceIDPrefix
+	}
+	return weatherSourceIDPrefix + "-" + status.ApartmentId
 }
 
 func (c *WeatherModule) weatherStateTopic(measurement string) string {
-	deviceName := c.weatherStation.Attributes.Name
+	deviceName := weatherSourceName
 	if c.normalizeDeviceName {
 		deviceName = normalizeForTopicName(deviceName)
 	}
@@ -164,14 +174,14 @@ func (c *WeatherModule) weatherStateTopic(measurement string) string {
 }
 
 func (c *WeatherModule) GetHomeAssistantEntities() ([]homeassistant.DiscoveryConfig, error) {
-	if c.weatherStation == nil {
+	if c.weatherSourceID == "" {
 		return []homeassistant.DiscoveryConfig{}, nil
 	}
 
 	device := homeassistant.Device{
-		Identifiers: []string{c.weatherStation.DeviceId},
+		Identifiers: []string{c.weatherSourceID},
 		Model:       "dS-Weather",
-		Name:        c.weatherStation.Attributes.Name,
+		Name:        weatherSourceName,
 	}
 	configs := []homeassistant.DiscoveryConfig{
 		c.sensorConfig(device, weatherTemperature, "°C", "temperature"),
@@ -180,13 +190,13 @@ func (c *WeatherModule) GetHomeAssistantEntities() ([]homeassistant.DiscoveryCon
 		c.sensorConfig(device, weatherWindGust, "m/s", "wind_speed"),
 		{
 			Domain:   homeassistant.BinarySensor,
-			DeviceId: c.weatherStation.DeviceId,
+			DeviceId: c.weatherSourceID,
 			ObjectId: weatherRain,
 			Config: &homeassistant.BinarySensorConfig{
 				BaseConfig: homeassistant.BaseConfig{
 					Device:   device,
 					Name:     weatherRain,
-					UniqueId: c.weatherStation.DeviceId + "_" + weatherRain,
+					UniqueId: c.weatherSourceID + "_" + weatherRain,
 				},
 				StateTopic:  c.mqttClient.GetFullTopic(c.weatherStateTopic(weatherRain)),
 				DeviceClass: "moisture",
@@ -202,13 +212,13 @@ func (c *WeatherModule) GetHomeAssistantEntities() ([]homeassistant.DiscoveryCon
 func (c *WeatherModule) sensorConfig(device homeassistant.Device, measurement string, unit string, deviceClass string) homeassistant.DiscoveryConfig {
 	return homeassistant.DiscoveryConfig{
 		Domain:   homeassistant.Sensor,
-		DeviceId: c.weatherStation.DeviceId,
+		DeviceId: c.weatherSourceID,
 		ObjectId: measurement,
 		Config: &homeassistant.SensorConfig{
 			BaseConfig: homeassistant.BaseConfig{
 				Device:   device,
 				Name:     measurement,
-				UniqueId: c.weatherStation.DeviceId + "_" + measurement,
+				UniqueId: c.weatherSourceID + "_" + measurement,
 			},
 			StateTopic:        c.mqttClient.GetFullTopic(c.weatherStateTopic(measurement)),
 			UnitOfMeasurement: unit,

--- a/pkg/controller/modules/weather.go
+++ b/pkg/controller/modules/weather.go
@@ -1,0 +1,231 @@
+package modules
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/gaetancollaud/digitalstrom-mqtt/pkg/config"
+	"github.com/gaetancollaud/digitalstrom-mqtt/pkg/digitalstrom"
+	"github.com/gaetancollaud/digitalstrom-mqtt/pkg/homeassistant"
+	"github.com/gaetancollaud/digitalstrom-mqtt/pkg/mqtt"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	weatherModuleID       = "weather"
+	weatherStationSensors = "weather_station_sensors"
+	weatherTemperature    = "temperature"
+	weatherIlluminance    = "illuminance"
+	weatherWindSpeed      = "wind_speed_10min_average"
+	weatherWindGust       = "wind_gust"
+	weatherRain           = "rain"
+	weatherStateOn        = "ON"
+	weatherStateOff       = "OFF"
+)
+
+type WeatherModule struct {
+	mqttClient          mqtt.Client
+	dsRegistry          digitalstrom.Registry
+	normalizeDeviceName bool
+	weatherStation      *digitalstrom.Device
+	subscribed          bool
+}
+
+func (c *WeatherModule) Start() error {
+	station, err := c.findWeatherStation()
+	if err != nil {
+		return err
+	}
+	if station == nil {
+		log.Debug().Msg("No dS-Weather station found. Weather module disabled.")
+		return nil
+	}
+	c.weatherStation = station
+	log.Debug().
+		Str("device", station.Attributes.Name).
+		Msg("Weather module enabled.")
+
+	status, err := c.dsRegistry.GetApartmentStatus()
+	if err != nil {
+		return fmt.Errorf("error getting apartment weather status: %w", err)
+	}
+	if err := c.publishWeatherStatus(status); err != nil {
+		return err
+	}
+	if err := c.dsRegistry.ApartmentStatusChangeSubscribe(weatherModuleID, func(oldStatus *digitalstrom.ApartmentStatus, newStatus *digitalstrom.ApartmentStatus) {
+		if weatherStatusEqual(oldStatus, newStatus) {
+			return
+		}
+		if err := c.publishWeatherStatus(newStatus); err != nil {
+			log.Error().Err(err).Msg("Error publishing dS-Weather status")
+		}
+	}); err != nil {
+		return err
+	}
+	c.subscribed = true
+	return nil
+}
+
+func (c *WeatherModule) Stop() error {
+	if !c.subscribed {
+		return nil
+	}
+	c.subscribed = false
+	return c.dsRegistry.ApartmentStatusChangeUnsubscribe(weatherModuleID)
+}
+
+func (c *WeatherModule) findWeatherStation() (*digitalstrom.Device, error) {
+	devices, err := c.dsRegistry.GetDevices()
+	if err != nil {
+		return nil, err
+	}
+	for _, device := range devices {
+		functionBlock, err := c.dsRegistry.GetFunctionBlockForDevice(device.DeviceId)
+		if err != nil {
+			continue
+		}
+		if strings.EqualFold(functionBlock.Attributes.TechnicalName, "Weather") {
+			station := device
+			return &station, nil
+		}
+	}
+	return nil, nil
+}
+
+func (c *WeatherModule) publishWeatherStatus(status *digitalstrom.ApartmentStatus) error {
+	if status == nil || c.weatherStation == nil {
+		return nil
+	}
+	measurements := status.Attributes.Measurements
+	values := []struct {
+		measurement string
+		value       *float64
+		format      string
+	}{
+		{weatherTemperature, measurements.Temperature, "%.2f"},
+		{weatherIlluminance, measurements.Brightness, "%.0f"},
+		{weatherWindSpeed, measurements.WindSpeed, "%.2f"},
+		{weatherWindGust, measurements.WindGust, "%.2f"},
+	}
+	for _, item := range values {
+		if item.value == nil {
+			continue
+		}
+		if err := c.mqttClient.Publish(c.weatherStateTopic(item.measurement), fmt.Sprintf(item.format, *item.value)); err != nil {
+			return fmt.Errorf("error publishing dS-Weather %s: %w", item.measurement, err)
+		}
+	}
+	if rain := status.Attributes.Weather.Rain; rain != nil {
+		value := weatherStateOff
+		if *rain {
+			value = weatherStateOn
+		}
+		if err := c.mqttClient.Publish(c.weatherStateTopic(weatherRain), value); err != nil {
+			return fmt.Errorf("error publishing dS-Weather rain: %w", err)
+		}
+	}
+	return nil
+}
+
+func weatherStatusEqual(oldStatus *digitalstrom.ApartmentStatus, newStatus *digitalstrom.ApartmentStatus) bool {
+	if oldStatus == nil || newStatus == nil {
+		return oldStatus == newStatus
+	}
+	oldMeasurements := oldStatus.Attributes.Measurements
+	newMeasurements := newStatus.Attributes.Measurements
+	return equalFloat(oldMeasurements.Temperature, newMeasurements.Temperature) &&
+		equalFloat(oldMeasurements.Brightness, newMeasurements.Brightness) &&
+		equalFloat(oldMeasurements.WindSpeed, newMeasurements.WindSpeed) &&
+		equalFloat(oldMeasurements.WindGust, newMeasurements.WindGust) &&
+		equalBool(oldStatus.Attributes.Weather.Rain, newStatus.Attributes.Weather.Rain)
+}
+
+func equalFloat(left *float64, right *float64) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
+}
+
+func equalBool(left *bool, right *bool) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
+}
+
+func (c *WeatherModule) weatherStateTopic(measurement string) string {
+	deviceName := c.weatherStation.Attributes.Name
+	if c.normalizeDeviceName {
+		deviceName = normalizeForTopicName(deviceName)
+	}
+	return path.Join(weatherStationSensors, deviceName, measurement, mqtt.State)
+}
+
+func (c *WeatherModule) GetHomeAssistantEntities() ([]homeassistant.DiscoveryConfig, error) {
+	if c.weatherStation == nil {
+		return []homeassistant.DiscoveryConfig{}, nil
+	}
+
+	device := homeassistant.Device{
+		Identifiers: []string{c.weatherStation.DeviceId},
+		Model:       "dS-Weather",
+		Name:        c.weatherStation.Attributes.Name,
+	}
+	configs := []homeassistant.DiscoveryConfig{
+		c.sensorConfig(device, weatherTemperature, "°C", "temperature"),
+		c.sensorConfig(device, weatherIlluminance, "lx", "illuminance"),
+		c.sensorConfig(device, weatherWindSpeed, "m/s", "wind_speed"),
+		c.sensorConfig(device, weatherWindGust, "m/s", "wind_speed"),
+		{
+			Domain:   homeassistant.BinarySensor,
+			DeviceId: c.weatherStation.DeviceId,
+			ObjectId: weatherRain,
+			Config: &homeassistant.BinarySensorConfig{
+				BaseConfig: homeassistant.BaseConfig{
+					Device:   device,
+					Name:     weatherRain,
+					UniqueId: c.weatherStation.DeviceId + "_" + weatherRain,
+				},
+				StateTopic:  c.mqttClient.GetFullTopic(c.weatherStateTopic(weatherRain)),
+				DeviceClass: "moisture",
+				PayloadOn:   weatherStateOn,
+				PayloadOff:  weatherStateOff,
+				Icon:        "mdi:weather-pouring",
+			},
+		},
+	}
+	return configs, nil
+}
+
+func (c *WeatherModule) sensorConfig(device homeassistant.Device, measurement string, unit string, deviceClass string) homeassistant.DiscoveryConfig {
+	return homeassistant.DiscoveryConfig{
+		Domain:   homeassistant.Sensor,
+		DeviceId: c.weatherStation.DeviceId,
+		ObjectId: measurement,
+		Config: &homeassistant.SensorConfig{
+			BaseConfig: homeassistant.BaseConfig{
+				Device:   device,
+				Name:     measurement,
+				UniqueId: c.weatherStation.DeviceId + "_" + measurement,
+			},
+			StateTopic:        c.mqttClient.GetFullTopic(c.weatherStateTopic(measurement)),
+			UnitOfMeasurement: unit,
+			DeviceClass:       deviceClass,
+			StateClass:        "measurement",
+		},
+	}
+}
+
+func NewWeatherModule(mqttClient mqtt.Client, _ digitalstrom.Client, dsRegistry digitalstrom.Registry, config *config.Config) Module {
+	return &WeatherModule{
+		mqttClient:          mqttClient,
+		dsRegistry:          dsRegistry,
+		normalizeDeviceName: config.Mqtt.NormalizeDeviceName,
+	}
+}
+
+func init() {
+	Register(weatherModuleID, NewWeatherModule)
+}

--- a/pkg/controller/modules/weather.go
+++ b/pkg/controller/modules/weather.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/gaetancollaud/digitalstrom-mqtt/pkg/config"
 	"github.com/gaetancollaud/digitalstrom-mqtt/pkg/digitalstrom"
@@ -33,6 +34,12 @@ type WeatherModule struct {
 	normalizeDeviceName bool
 	weatherSourceID     string
 	subscribed          bool
+	publishMu           sync.Mutex
+	lastPublished       *apartmentWeatherValues
+}
+
+type functionBlocksForDeviceRegistry interface {
+	GetFunctionBlocksForDevice(deviceId string) ([]digitalstrom.FunctionBlock, error)
 }
 
 func (c *WeatherModule) Start() error {
@@ -54,14 +61,11 @@ func (c *WeatherModule) Start() error {
 		Int("weather_stations", stationCount).
 		Str("weather_source", c.weatherSourceID).
 		Msg("Weather module enabled with apartment-wide weather data.")
-	if err := c.publishWeatherStatus(status); err != nil {
+	if err := c.publishWeatherStatusIfChanged(status); err != nil {
 		return err
 	}
-	if err := c.dsRegistry.ApartmentStatusChangeSubscribe(weatherModuleID, func(oldStatus *digitalstrom.ApartmentStatus, newStatus *digitalstrom.ApartmentStatus) {
-		if weatherStatusEqual(oldStatus, newStatus) {
-			return
-		}
-		if err := c.publishWeatherStatus(newStatus); err != nil {
+	if err := c.dsRegistry.ApartmentStatusChangeSubscribe(weatherModuleID, func(_ *digitalstrom.ApartmentStatus, newStatus *digitalstrom.ApartmentStatus) {
+		if err := c.publishWeatherStatusIfChanged(newStatus); err != nil {
 			log.Error().Err(err).Msg("Error publishing dS-Weather status")
 		}
 	}); err != nil {
@@ -75,8 +79,11 @@ func (c *WeatherModule) Stop() error {
 	if !c.subscribed {
 		return nil
 	}
+	if err := c.dsRegistry.ApartmentStatusChangeUnsubscribe(weatherModuleID); err != nil {
+		return err
+	}
 	c.subscribed = false
-	return c.dsRegistry.ApartmentStatusChangeUnsubscribe(weatherModuleID)
+	return nil
 }
 
 func (c *WeatherModule) countWeatherStations() (int, error) {
@@ -86,15 +93,45 @@ func (c *WeatherModule) countWeatherStations() (int, error) {
 	}
 	stationCount := 0
 	for _, device := range devices {
-		functionBlock, err := c.dsRegistry.GetFunctionBlockForDevice(device.DeviceId)
+		functionBlocks, err := c.getFunctionBlocksForDevice(device.DeviceId)
 		if err != nil {
+			log.Debug().Err(err).Str("device_id", device.DeviceId).Msg("Unable to inspect device for dS-Weather support")
 			continue
 		}
-		if strings.EqualFold(functionBlock.Attributes.TechnicalName, "Weather") {
-			stationCount++
+		for _, functionBlock := range functionBlocks {
+			if strings.EqualFold(functionBlock.Attributes.TechnicalName, "Weather") {
+				stationCount++
+				break
+			}
 		}
 	}
 	return stationCount, nil
+}
+
+func (c *WeatherModule) getFunctionBlocksForDevice(deviceID string) ([]digitalstrom.FunctionBlock, error) {
+	if registry, ok := c.dsRegistry.(functionBlocksForDeviceRegistry); ok {
+		return registry.GetFunctionBlocksForDevice(deviceID)
+	}
+	functionBlock, err := c.dsRegistry.GetFunctionBlockForDevice(deviceID)
+	if err != nil {
+		return nil, err
+	}
+	return []digitalstrom.FunctionBlock{functionBlock}, nil
+}
+
+func (c *WeatherModule) publishWeatherStatusIfChanged(status *digitalstrom.ApartmentStatus) error {
+	c.publishMu.Lock()
+	defer c.publishMu.Unlock()
+
+	values := weatherValues(status)
+	if reflect.DeepEqual(c.lastPublished, values) {
+		return nil
+	}
+	if err := c.publishWeatherStatus(status); err != nil {
+		return err
+	}
+	c.lastPublished = values
+	return nil
 }
 
 func (c *WeatherModule) publishWeatherStatus(status *digitalstrom.ApartmentStatus) error {
@@ -130,10 +167,6 @@ func (c *WeatherModule) publishWeatherStatus(status *digitalstrom.ApartmentStatu
 		}
 	}
 	return nil
-}
-
-func weatherStatusEqual(oldStatus *digitalstrom.ApartmentStatus, newStatus *digitalstrom.ApartmentStatus) bool {
-	return reflect.DeepEqual(weatherValues(oldStatus), weatherValues(newStatus))
 }
 
 type apartmentWeatherValues struct {

--- a/pkg/controller/modules/weather_test.go
+++ b/pkg/controller/modules/weather_test.go
@@ -1,0 +1,205 @@
+package modules
+
+import (
+	"path"
+	"testing"
+
+	"github.com/gaetancollaud/digitalstrom-mqtt/pkg/digitalstrom"
+	"github.com/gaetancollaud/digitalstrom-mqtt/pkg/homeassistant"
+	"github.com/gaetancollaud/digitalstrom-mqtt/pkg/mqtt"
+)
+
+type weatherMQTTClientStub struct {
+	mqtt.Client
+	prefix    string
+	published map[string]interface{}
+}
+
+func (c *weatherMQTTClientStub) Publish(topic string, value interface{}) error {
+	c.published[topic] = value
+	return nil
+}
+
+func (c *weatherMQTTClientStub) GetFullTopic(topic string) string {
+	return path.Join(c.prefix, topic)
+}
+
+type weatherRegistryStub struct {
+	digitalstrom.Registry
+	devices        []digitalstrom.Device
+	functionBlocks map[string]digitalstrom.FunctionBlock
+	status         *digitalstrom.ApartmentStatus
+	callback       digitalstrom.ApartmentStatusChangeCallback
+}
+
+func (r *weatherRegistryStub) GetDevices() ([]digitalstrom.Device, error) {
+	return r.devices, nil
+}
+
+func (r *weatherRegistryStub) GetFunctionBlockForDevice(deviceID string) (digitalstrom.FunctionBlock, error) {
+	return r.functionBlocks[deviceID], nil
+}
+
+func (r *weatherRegistryStub) GetApartmentStatus() (*digitalstrom.ApartmentStatus, error) {
+	return r.status, nil
+}
+
+func (r *weatherRegistryStub) ApartmentStatusChangeSubscribe(_ string, callback digitalstrom.ApartmentStatusChangeCallback) error {
+	r.callback = callback
+	return nil
+}
+
+func (r *weatherRegistryStub) ApartmentStatusChangeUnsubscribe(_ string) error {
+	r.callback = nil
+	return nil
+}
+
+func TestWeatherModulePublishesModernApartmentStatus(t *testing.T) {
+	temperature := 21.5
+	brightness := 12345.0
+	windSpeed := 2.25
+	windGust := 4.75
+	rain := true
+	status := &digitalstrom.ApartmentStatus{
+		Attributes: digitalstrom.ApartmentStatusAttributes{
+			Measurements: digitalstrom.ApartmentMeasurements{
+				Temperature: &temperature,
+				Brightness:  &brightness,
+				WindSpeed:   &windSpeed,
+				WindGust:    &windGust,
+			},
+			Weather: digitalstrom.ApartmentWeatherStatus{Rain: &rain},
+		},
+	}
+	mqttClient := &weatherMQTTClientStub{prefix: "digitalstrom", published: map[string]interface{}{}}
+	registry := &weatherRegistryStub{
+		devices: []digitalstrom.Device{{
+			DeviceId: "weather-1",
+			Attributes: digitalstrom.DeviceAttributes{
+				Name: "Roof Weather",
+			},
+		}},
+		functionBlocks: map[string]digitalstrom.FunctionBlock{
+			"weather-1": {Attributes: digitalstrom.FunctionBlockAttributes{TechnicalName: "Weather"}},
+		},
+		status: status,
+	}
+	module := &WeatherModule{mqttClient: mqttClient, dsRegistry: registry, normalizeDeviceName: true}
+
+	if err := module.Start(); err != nil {
+		t.Fatalf("expected weather module to start: %v", err)
+	}
+	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/Roof_Weather/temperature/state", "21.50")
+	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/Roof_Weather/illuminance/state", "12345")
+	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/Roof_Weather/wind_speed_10min_average/state", "2.25")
+	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/Roof_Weather/wind_gust/state", "4.75")
+	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/Roof_Weather/rain/state", "ON")
+	if registry.callback == nil {
+		t.Fatal("expected apartment status subscription")
+	}
+	updatedWindSpeed := 3.0
+	updatedRain := false
+	updatedStatus := *status
+	updatedStatus.Attributes.Measurements.WindSpeed = &updatedWindSpeed
+	updatedStatus.Attributes.Weather.Rain = &updatedRain
+	registry.callback(status, &updatedStatus)
+	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/Roof_Weather/wind_speed_10min_average/state", "3.00")
+	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/Roof_Weather/rain/state", "OFF")
+
+	configs, err := module.GetHomeAssistantEntities()
+	if err != nil {
+		t.Fatalf("expected Home Assistant configs: %v", err)
+	}
+	if len(configs) != 5 {
+		t.Fatalf("expected five Home Assistant configs, got %d", len(configs))
+	}
+	assertWeatherConfig(t, configs, weatherTemperature, homeassistant.Sensor)
+	assertWeatherConfig(t, configs, weatherIlluminance, homeassistant.Sensor)
+	assertWeatherConfig(t, configs, weatherWindSpeed, homeassistant.Sensor)
+	assertWeatherConfig(t, configs, weatherWindGust, homeassistant.Sensor)
+	assertWeatherConfig(t, configs, weatherRain, homeassistant.BinarySensor)
+
+	if err := module.Stop(); err != nil {
+		t.Fatalf("expected weather module to stop: %v", err)
+	}
+	if registry.callback != nil {
+		t.Fatal("expected apartment status subscription to be removed")
+	}
+}
+
+func TestWeatherModuleUsesTechnicalNameInsteadOfDisplayName(t *testing.T) {
+	module := &WeatherModule{
+		mqttClient: &weatherMQTTClientStub{published: map[string]interface{}{}},
+		dsRegistry: &weatherRegistryStub{
+			devices: []digitalstrom.Device{{DeviceId: "weather-1", Attributes: digitalstrom.DeviceAttributes{Name: "Custom Device Name"}}},
+			functionBlocks: map[string]digitalstrom.FunctionBlock{
+				"weather-1": {Attributes: digitalstrom.FunctionBlockAttributes{TechnicalName: "Weather"}},
+			},
+			status: &digitalstrom.ApartmentStatus{},
+		},
+	}
+	if err := module.Start(); err != nil {
+		t.Fatalf("expected weather module to recognize technical name: %v", err)
+	}
+	if module.weatherStation == nil || module.weatherStation.DeviceId != "weather-1" {
+		t.Fatalf("expected weather station detection, got %#v", module.weatherStation)
+	}
+}
+
+func TestWeatherModuleDiscoversAllEntitiesWithPartialInitialStatus(t *testing.T) {
+	temperature := 19.25
+	status := &digitalstrom.ApartmentStatus{
+		Attributes: digitalstrom.ApartmentStatusAttributes{
+			Measurements: digitalstrom.ApartmentMeasurements{Temperature: &temperature},
+		},
+	}
+	mqttClient := &weatherMQTTClientStub{prefix: "digitalstrom", published: map[string]interface{}{}}
+	registry := &weatherRegistryStub{
+		devices: []digitalstrom.Device{{
+			DeviceId:   "weather-1",
+			Attributes: digitalstrom.DeviceAttributes{Name: "Partial Weather"},
+		}},
+		functionBlocks: map[string]digitalstrom.FunctionBlock{
+			"weather-1": {Attributes: digitalstrom.FunctionBlockAttributes{TechnicalName: "Weather"}},
+		},
+		status: status,
+	}
+	module := &WeatherModule{mqttClient: mqttClient, dsRegistry: registry}
+
+	if err := module.Start(); err != nil {
+		t.Fatalf("expected weather module to start: %v", err)
+	}
+	if len(mqttClient.published) != 1 {
+		t.Fatalf("expected only the available value to be published, got %#v", mqttClient.published)
+	}
+	configs, err := module.GetHomeAssistantEntities()
+	if err != nil {
+		t.Fatalf("expected Home Assistant configs: %v", err)
+	}
+	if len(configs) != 5 {
+		t.Fatalf("expected all five weather entities, got %#v", configs)
+	}
+}
+
+func assertPublishedWeatherValue(t *testing.T, client *weatherMQTTClientStub, topic string, expected interface{}) {
+	t.Helper()
+	if actual := client.published[topic]; actual != expected {
+		t.Fatalf("expected %s=%v, got %v", topic, expected, actual)
+	}
+}
+
+func assertWeatherConfig(t *testing.T, configs []homeassistant.DiscoveryConfig, objectID string, domain homeassistant.Domain) {
+	t.Helper()
+	for _, config := range configs {
+		if config.ObjectId == objectID {
+			if config.Domain != domain {
+				t.Fatalf("expected %s domain %s, got %s", objectID, domain, config.Domain)
+			}
+			if config.DeviceId != "weather-1" {
+				t.Fatalf("expected stable device id, got %s", config.DeviceId)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing Home Assistant config %s", objectID)
+}

--- a/pkg/controller/modules/weather_test.go
+++ b/pkg/controller/modules/weather_test.go
@@ -61,6 +61,7 @@ func TestWeatherModulePublishesModernApartmentStatus(t *testing.T) {
 	windGust := 4.75
 	rain := true
 	status := &digitalstrom.ApartmentStatus{
+		ApartmentId: "apartment-1",
 		Attributes: digitalstrom.ApartmentStatusAttributes{
 			Measurements: digitalstrom.ApartmentMeasurements{
 				Temperature: &temperature,
@@ -89,11 +90,11 @@ func TestWeatherModulePublishesModernApartmentStatus(t *testing.T) {
 	if err := module.Start(); err != nil {
 		t.Fatalf("expected weather module to start: %v", err)
 	}
-	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/Roof_Weather/temperature/state", "21.50")
-	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/Roof_Weather/illuminance/state", "12345")
-	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/Roof_Weather/wind_speed_10min_average/state", "2.25")
-	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/Roof_Weather/wind_gust/state", "4.75")
-	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/Roof_Weather/rain/state", "ON")
+	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/dS-Weather/temperature/state", "21.50")
+	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/dS-Weather/illuminance/state", "12345")
+	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/dS-Weather/wind_speed_10min_average/state", "2.25")
+	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/dS-Weather/wind_gust/state", "4.75")
+	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/dS-Weather/rain/state", "ON")
 	if registry.callback == nil {
 		t.Fatal("expected apartment status subscription")
 	}
@@ -103,8 +104,8 @@ func TestWeatherModulePublishesModernApartmentStatus(t *testing.T) {
 	updatedStatus.Attributes.Measurements.WindSpeed = &updatedWindSpeed
 	updatedStatus.Attributes.Weather.Rain = &updatedRain
 	registry.callback(status, &updatedStatus)
-	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/Roof_Weather/wind_speed_10min_average/state", "3.00")
-	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/Roof_Weather/rain/state", "OFF")
+	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/dS-Weather/wind_speed_10min_average/state", "3.00")
+	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/dS-Weather/rain/state", "OFF")
 
 	configs, err := module.GetHomeAssistantEntities()
 	if err != nil {
@@ -141,14 +142,90 @@ func TestWeatherModuleUsesTechnicalNameInsteadOfDisplayName(t *testing.T) {
 	if err := module.Start(); err != nil {
 		t.Fatalf("expected weather module to recognize technical name: %v", err)
 	}
-	if module.weatherStation == nil || module.weatherStation.DeviceId != "weather-1" {
-		t.Fatalf("expected weather station detection, got %#v", module.weatherStation)
+	if module.weatherSourceID != weatherSourceIDPrefix {
+		t.Fatalf("expected weather source detection, got %q", module.weatherSourceID)
+	}
+}
+
+func TestWeatherModuleRepresentsMultipleStationsAsOneApartmentSource(t *testing.T) {
+	status := &digitalstrom.ApartmentStatus{ApartmentId: "apartment-1"}
+	registry := &weatherRegistryStub{
+		devices: []digitalstrom.Device{
+			{DeviceId: "weather-1", Attributes: digitalstrom.DeviceAttributes{Name: "North Weather"}},
+			{DeviceId: "weather-2", Attributes: digitalstrom.DeviceAttributes{Name: "South Weather"}},
+		},
+		functionBlocks: map[string]digitalstrom.FunctionBlock{
+			"weather-1": {Attributes: digitalstrom.FunctionBlockAttributes{TechnicalName: "Weather"}},
+			"weather-2": {Attributes: digitalstrom.FunctionBlockAttributes{TechnicalName: "weather"}},
+		},
+		status: status,
+	}
+	module := &WeatherModule{
+		mqttClient: &weatherMQTTClientStub{prefix: "digitalstrom", published: map[string]interface{}{}},
+		dsRegistry: registry,
+	}
+
+	if err := module.Start(); err != nil {
+		t.Fatalf("expected weather module to start: %v", err)
+	}
+	if module.weatherSourceID != "apartment-weather-apartment-1" {
+		t.Fatalf("expected apartment-scoped weather source, got %q", module.weatherSourceID)
+	}
+	configs, err := module.GetHomeAssistantEntities()
+	if err != nil {
+		t.Fatalf("expected Home Assistant configs: %v", err)
+	}
+	if len(configs) != 5 {
+		t.Fatalf("expected one apartment weather source with five entities, got %d", len(configs))
+	}
+	for _, config := range configs {
+		if config.DeviceId != "apartment-weather-apartment-1" {
+			t.Fatalf("expected apartment-scoped device id, got %q", config.DeviceId)
+		}
+	}
+}
+
+func TestWeatherStatusEqualComparesOnlyWeatherValues(t *testing.T) {
+	temperature := 21.5
+	sameTemperature := 21.5
+	differentTemperature := 22.0
+	oldStatus := &digitalstrom.ApartmentStatus{
+		Attributes: digitalstrom.ApartmentStatusAttributes{
+			Measurements: digitalstrom.ApartmentMeasurements{Temperature: &temperature},
+		},
+		Included: digitalstrom.ApartmentStatusIncluded{
+			Devices: []digitalstrom.DeviceStatus{{DeviceId: "device-1"}},
+		},
+	}
+	sameWeather := &digitalstrom.ApartmentStatus{
+		Attributes: digitalstrom.ApartmentStatusAttributes{
+			Measurements: digitalstrom.ApartmentMeasurements{Temperature: &sameTemperature},
+		},
+		Included: digitalstrom.ApartmentStatusIncluded{
+			Devices: []digitalstrom.DeviceStatus{{DeviceId: "device-2"}},
+		},
+	}
+	changedWeather := &digitalstrom.ApartmentStatus{
+		Attributes: digitalstrom.ApartmentStatusAttributes{
+			Measurements: digitalstrom.ApartmentMeasurements{Temperature: &differentTemperature},
+		},
+	}
+
+	if !weatherStatusEqual(oldStatus, sameWeather) {
+		t.Fatal("expected equal weather values with different pointers and unrelated device status")
+	}
+	if weatherStatusEqual(oldStatus, changedWeather) {
+		t.Fatal("expected changed weather values to differ")
+	}
+	if !weatherStatusEqual(nil, nil) || weatherStatusEqual(nil, oldStatus) {
+		t.Fatal("expected nil apartment status to compare safely")
 	}
 }
 
 func TestWeatherModuleDiscoversAllEntitiesWithPartialInitialStatus(t *testing.T) {
 	temperature := 19.25
 	status := &digitalstrom.ApartmentStatus{
+		ApartmentId: "apartment-1",
 		Attributes: digitalstrom.ApartmentStatusAttributes{
 			Measurements: digitalstrom.ApartmentMeasurements{Temperature: &temperature},
 		},
@@ -195,7 +272,7 @@ func assertWeatherConfig(t *testing.T, configs []homeassistant.DiscoveryConfig, 
 			if config.Domain != domain {
 				t.Fatalf("expected %s domain %s, got %s", objectID, domain, config.Domain)
 			}
-			if config.DeviceId != "weather-1" {
+			if config.DeviceId != "apartment-weather-apartment-1" {
 				t.Fatalf("expected stable device id, got %s", config.DeviceId)
 			}
 			return

--- a/pkg/controller/modules/weather_test.go
+++ b/pkg/controller/modules/weather_test.go
@@ -1,6 +1,7 @@
 package modules
 
 import (
+	"errors"
 	"path"
 	"testing"
 
@@ -11,11 +12,17 @@ import (
 
 type weatherMQTTClientStub struct {
 	mqtt.Client
-	prefix    string
-	published map[string]interface{}
+	prefix       string
+	published    map[string]interface{}
+	publishErr   error
+	publishCalls int
 }
 
 func (c *weatherMQTTClientStub) Publish(topic string, value interface{}) error {
+	c.publishCalls++
+	if c.publishErr != nil {
+		return c.publishErr
+	}
 	c.published[topic] = value
 	return nil
 }
@@ -26,30 +33,61 @@ func (c *weatherMQTTClientStub) GetFullTopic(topic string) string {
 
 type weatherRegistryStub struct {
 	digitalstrom.Registry
-	devices        []digitalstrom.Device
-	functionBlocks map[string]digitalstrom.FunctionBlock
-	status         *digitalstrom.ApartmentStatus
-	callback       digitalstrom.ApartmentStatusChangeCallback
+	devices             []digitalstrom.Device
+	devicesErr          error
+	functionBlocks      map[string]digitalstrom.FunctionBlock
+	functionBlockLists  map[string][]digitalstrom.FunctionBlock
+	functionBlockErrors map[string]error
+	status              *digitalstrom.ApartmentStatus
+	statusErr           error
+	callback            digitalstrom.ApartmentStatusChangeCallback
+	subscribeErr        error
+	unsubscribeErrors   []error
+	unsubscribeCalls    int
 }
 
 func (r *weatherRegistryStub) GetDevices() ([]digitalstrom.Device, error) {
-	return r.devices, nil
+	return r.devices, r.devicesErr
 }
 
 func (r *weatherRegistryStub) GetFunctionBlockForDevice(deviceID string) (digitalstrom.FunctionBlock, error) {
 	return r.functionBlocks[deviceID], nil
 }
 
+func (r *weatherRegistryStub) GetFunctionBlocksForDevice(deviceID string) ([]digitalstrom.FunctionBlock, error) {
+	if err := r.functionBlockErrors[deviceID]; err != nil {
+		return nil, err
+	}
+	if functionBlocks, ok := r.functionBlockLists[deviceID]; ok {
+		return functionBlocks, nil
+	}
+	if functionBlock, ok := r.functionBlocks[deviceID]; ok {
+		return []digitalstrom.FunctionBlock{functionBlock}, nil
+	}
+	return []digitalstrom.FunctionBlock{}, nil
+}
+
 func (r *weatherRegistryStub) GetApartmentStatus() (*digitalstrom.ApartmentStatus, error) {
-	return r.status, nil
+	return r.status, r.statusErr
 }
 
 func (r *weatherRegistryStub) ApartmentStatusChangeSubscribe(_ string, callback digitalstrom.ApartmentStatusChangeCallback) error {
+	if r.subscribeErr != nil {
+		return r.subscribeErr
+	}
 	r.callback = callback
 	return nil
 }
 
 func (r *weatherRegistryStub) ApartmentStatusChangeUnsubscribe(_ string) error {
+	r.unsubscribeCalls++
+	if len(r.unsubscribeErrors) > 0 {
+		err := r.unsubscribeErrors[0]
+		r.unsubscribeErrors = r.unsubscribeErrors[1:]
+		if err != nil {
+			return err
+		}
+	}
 	r.callback = nil
 	return nil
 }
@@ -185,40 +223,164 @@ func TestWeatherModuleRepresentsMultipleStationsAsOneApartmentSource(t *testing.
 	}
 }
 
-func TestWeatherStatusEqualComparesOnlyWeatherValues(t *testing.T) {
-	temperature := 21.5
-	sameTemperature := 21.5
-	differentTemperature := 22.0
-	oldStatus := &digitalstrom.ApartmentStatus{
-		Attributes: digitalstrom.ApartmentStatusAttributes{
-			Measurements: digitalstrom.ApartmentMeasurements{Temperature: &temperature},
+func TestWeatherModuleFindsWeatherFunctionBlockAmongMultipleBlocks(t *testing.T) {
+	registry := &weatherRegistryStub{
+		devices: []digitalstrom.Device{{DeviceId: "weather-1"}},
+		functionBlockLists: map[string][]digitalstrom.FunctionBlock{
+			"weather-1": {
+				{Attributes: digitalstrom.FunctionBlockAttributes{TechnicalName: "Sensor"}},
+				{Attributes: digitalstrom.FunctionBlockAttributes{TechnicalName: "Weather"}},
+			},
 		},
-		Included: digitalstrom.ApartmentStatusIncluded{
-			Devices: []digitalstrom.DeviceStatus{{DeviceId: "device-1"}},
+		status: &digitalstrom.ApartmentStatus{},
+	}
+	module := &WeatherModule{
+		mqttClient: &weatherMQTTClientStub{published: map[string]interface{}{}},
+		dsRegistry: registry,
+	}
+
+	if err := module.Start(); err != nil {
+		t.Fatalf("expected weather module to start: %v", err)
+	}
+	if module.weatherSourceID != weatherSourceIDPrefix {
+		t.Fatalf("expected weather source detection, got %q", module.weatherSourceID)
+	}
+}
+
+func TestWeatherModuleStaysDisabledWithoutWeatherStation(t *testing.T) {
+	mqttClient := &weatherMQTTClientStub{published: map[string]interface{}{}}
+	registry := &weatherRegistryStub{
+		devices: []digitalstrom.Device{{DeviceId: "light-1"}},
+		functionBlocks: map[string]digitalstrom.FunctionBlock{
+			"light-1": {Attributes: digitalstrom.FunctionBlockAttributes{TechnicalName: "Light"}},
 		},
 	}
-	sameWeather := &digitalstrom.ApartmentStatus{
-		Attributes: digitalstrom.ApartmentStatusAttributes{
-			Measurements: digitalstrom.ApartmentMeasurements{Temperature: &sameTemperature},
-		},
-		Included: digitalstrom.ApartmentStatusIncluded{
-			Devices: []digitalstrom.DeviceStatus{{DeviceId: "device-2"}},
-		},
+	module := &WeatherModule{mqttClient: mqttClient, dsRegistry: registry}
+
+	if err := module.Start(); err != nil {
+		t.Fatalf("expected weather module to stay disabled: %v", err)
 	}
-	changedWeather := &digitalstrom.ApartmentStatus{
-		Attributes: digitalstrom.ApartmentStatusAttributes{
-			Measurements: digitalstrom.ApartmentMeasurements{Temperature: &differentTemperature},
+	if module.weatherSourceID != "" || registry.callback != nil || mqttClient.publishCalls != 0 {
+		t.Fatal("expected disabled weather module without discovery or publication")
+	}
+}
+
+func TestWeatherModuleSkipsUnreadableDeviceAndFindsNextStation(t *testing.T) {
+	registry := &weatherRegistryStub{
+		devices: []digitalstrom.Device{{DeviceId: "broken-1"}, {DeviceId: "weather-1"}},
+		functionBlocks: map[string]digitalstrom.FunctionBlock{
+			"weather-1": {Attributes: digitalstrom.FunctionBlockAttributes{TechnicalName: "Weather"}},
+		},
+		functionBlockErrors: map[string]error{"broken-1": errors.New("function blocks unavailable")},
+		status:              &digitalstrom.ApartmentStatus{},
+	}
+	module := &WeatherModule{
+		mqttClient: &weatherMQTTClientStub{published: map[string]interface{}{}},
+		dsRegistry: registry,
+	}
+
+	if err := module.Start(); err != nil {
+		t.Fatalf("expected unreadable device to be isolated: %v", err)
+	}
+	if module.weatherSourceID != weatherSourceIDPrefix {
+		t.Fatalf("expected readable weather station to enable module, got %q", module.weatherSourceID)
+	}
+}
+
+func TestWeatherModuleStartReturnsDependencyErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		registry   *weatherRegistryStub
+		mqttClient *weatherMQTTClientStub
+	}{
+		{
+			name:     "devices",
+			registry: &weatherRegistryStub{devicesErr: errors.New("devices unavailable")},
+		},
+		{
+			name:     "apartment status",
+			registry: weatherRegistryWithError(errors.New("status unavailable"), nil),
+		},
+		{
+			name:       "initial publish",
+			registry:   weatherRegistryWithError(nil, nil),
+			mqttClient: &weatherMQTTClientStub{published: map[string]interface{}{}, publishErr: errors.New("mqtt unavailable")},
+		},
+		{
+			name:     "subscription",
+			registry: weatherRegistryWithError(nil, errors.New("subscribe unavailable")),
 		},
 	}
 
-	if !weatherStatusEqual(oldStatus, sameWeather) {
-		t.Fatal("expected equal weather values with different pointers and unrelated device status")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mqttClient := test.mqttClient
+			if mqttClient == nil {
+				mqttClient = &weatherMQTTClientStub{published: map[string]interface{}{}}
+			}
+			module := &WeatherModule{mqttClient: mqttClient, dsRegistry: test.registry}
+			if err := module.Start(); err == nil {
+				t.Fatal("expected weather module startup error")
+			}
+		})
 	}
-	if weatherStatusEqual(oldStatus, changedWeather) {
-		t.Fatal("expected changed weather values to differ")
+}
+
+func TestWeatherModuleRetriesFailedRuntimePublish(t *testing.T) {
+	temperature := 20.0
+	status := &digitalstrom.ApartmentStatus{
+		Attributes: digitalstrom.ApartmentStatusAttributes{
+			Measurements: digitalstrom.ApartmentMeasurements{Temperature: &temperature},
+		},
 	}
-	if !weatherStatusEqual(nil, nil) || weatherStatusEqual(nil, oldStatus) {
-		t.Fatal("expected nil apartment status to compare safely")
+	mqttClient := &weatherMQTTClientStub{published: map[string]interface{}{}}
+	registry := weatherRegistryWithError(nil, nil)
+	registry.status = status
+	module := &WeatherModule{mqttClient: mqttClient, dsRegistry: registry}
+	if err := module.Start(); err != nil {
+		t.Fatalf("expected weather module to start: %v", err)
+	}
+
+	updatedTemperature := 21.0
+	updatedStatus := &digitalstrom.ApartmentStatus{
+		Attributes: digitalstrom.ApartmentStatusAttributes{
+			Measurements: digitalstrom.ApartmentMeasurements{Temperature: &updatedTemperature},
+		},
+	}
+	mqttClient.publishErr = errors.New("temporary mqtt failure")
+	registry.callback(status, updatedStatus)
+	failedCallCount := mqttClient.publishCalls
+	mqttClient.publishErr = nil
+	registry.callback(updatedStatus, updatedStatus)
+
+	if mqttClient.publishCalls <= failedCallCount {
+		t.Fatal("expected unchanged apartment notification to retry failed weather publication")
+	}
+	assertPublishedWeatherValue(t, mqttClient, "weather_station_sensors/dS-Weather/temperature/state", "21.00")
+}
+
+func TestWeatherModuleRetriesFailedUnsubscribe(t *testing.T) {
+	registry := weatherRegistryWithError(nil, nil)
+	registry.unsubscribeErrors = []error{errors.New("temporary unsubscribe failure"), nil}
+	module := &WeatherModule{
+		mqttClient: &weatherMQTTClientStub{published: map[string]interface{}{}},
+		dsRegistry: registry,
+	}
+	if err := module.Start(); err != nil {
+		t.Fatalf("expected weather module to start: %v", err)
+	}
+
+	if err := module.Stop(); err == nil {
+		t.Fatal("expected first unsubscribe attempt to fail")
+	}
+	if !module.subscribed || registry.callback == nil {
+		t.Fatal("expected failed unsubscribe to preserve subscription state")
+	}
+	if err := module.Stop(); err != nil {
+		t.Fatalf("expected unsubscribe retry to succeed: %v", err)
+	}
+	if module.subscribed || registry.callback != nil || registry.unsubscribeCalls != 2 {
+		t.Fatal("expected successful retry to clear subscription state")
 	}
 }
 
@@ -279,4 +441,21 @@ func assertWeatherConfig(t *testing.T, configs []homeassistant.DiscoveryConfig, 
 		}
 	}
 	t.Fatalf("missing Home Assistant config %s", objectID)
+}
+
+func weatherRegistryWithError(statusErr error, subscribeErr error) *weatherRegistryStub {
+	temperature := 20.0
+	return &weatherRegistryStub{
+		devices: []digitalstrom.Device{{DeviceId: "weather-1"}},
+		functionBlocks: map[string]digitalstrom.FunctionBlock{
+			"weather-1": {Attributes: digitalstrom.FunctionBlockAttributes{TechnicalName: "Weather"}},
+		},
+		status: &digitalstrom.ApartmentStatus{
+			Attributes: digitalstrom.ApartmentStatusAttributes{
+				Measurements: digitalstrom.ApartmentMeasurements{Temperature: &temperature},
+			},
+		},
+		statusErr:    statusErr,
+		subscribeErr: subscribeErr,
+	}
 }

--- a/pkg/digitalstrom/api.go
+++ b/pkg/digitalstrom/api.go
@@ -213,8 +213,25 @@ type MeteringValueAttributes struct {
 // Status
 
 type ApartmentStatus struct {
-	ApartmentId string                  `mapstructure:"id"`
-	Included    ApartmentStatusIncluded `mapstructure:"included"`
+	ApartmentId string                    `mapstructure:"id"`
+	Attributes  ApartmentStatusAttributes `mapstructure:"attributes"`
+	Included    ApartmentStatusIncluded   `mapstructure:"included"`
+}
+
+type ApartmentStatusAttributes struct {
+	Weather      ApartmentWeatherStatus `mapstructure:"weather"`
+	Measurements ApartmentMeasurements  `mapstructure:"measurements"`
+}
+
+type ApartmentWeatherStatus struct {
+	Rain *bool `mapstructure:"rain"`
+}
+
+type ApartmentMeasurements struct {
+	Temperature *float64 `mapstructure:"temperature"`
+	Brightness  *float64 `mapstructure:"brightness"`
+	WindSpeed   *float64 `mapstructure:"windSpeed"`
+	WindGust    *float64 `mapstructure:"windGust"`
 }
 
 type ApartmentStatusIncluded struct {

--- a/pkg/digitalstrom/api_test.go
+++ b/pkg/digitalstrom/api_test.go
@@ -1,0 +1,49 @@
+package digitalstrom
+
+import "testing"
+
+func TestApartmentStatusDecodesWeatherMeasurements(t *testing.T) {
+	response := map[string]any{
+		"id": "apartment-1",
+		"attributes": map[string]any{
+			"weather": map[string]any{
+				"rain": true,
+			},
+			"measurements": map[string]any{
+				"temperature": 21.5,
+				"brightness":  12345.0,
+				"windSpeed":   2.25,
+				"windGust":    4.75,
+			},
+		},
+	}
+
+	status, err := wrapApiResponse[ApartmentStatus](response, nil)
+	if err != nil {
+		t.Fatalf("expected apartment status to decode: %v", err)
+	}
+	assertFloatPointer(t, "temperature", status.Attributes.Measurements.Temperature, 21.5)
+	assertFloatPointer(t, "brightness", status.Attributes.Measurements.Brightness, 12345.0)
+	assertFloatPointer(t, "windSpeed", status.Attributes.Measurements.WindSpeed, 2.25)
+	assertFloatPointer(t, "windGust", status.Attributes.Measurements.WindGust, 4.75)
+	if status.Attributes.Weather.Rain == nil || !*status.Attributes.Weather.Rain {
+		t.Fatalf("expected rain to decode as true, got %#v", status.Attributes.Weather.Rain)
+	}
+}
+
+func TestApartmentStatusKeepsMissingWeatherMeasurementsUnset(t *testing.T) {
+	status, err := wrapApiResponse[ApartmentStatus](map[string]any{"id": "apartment-1"}, nil)
+	if err != nil {
+		t.Fatalf("expected apartment status to decode: %v", err)
+	}
+	if status.Attributes.Measurements.Temperature != nil || status.Attributes.Weather.Rain != nil {
+		t.Fatalf("expected missing values to remain nil, got %#v", status.Attributes)
+	}
+}
+
+func assertFloatPointer(t *testing.T, name string, actual *float64, expected float64) {
+	t.Helper()
+	if actual == nil || *actual != expected {
+		t.Fatalf("expected %s %.2f, got %#v", name, expected, actual)
+	}
+}

--- a/pkg/digitalstrom/registry.go
+++ b/pkg/digitalstrom/registry.go
@@ -2,7 +2,6 @@ package digitalstrom
 
 import (
 	"errors"
-	"maps"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -299,8 +298,11 @@ func (r *registry) updateApartmentStatusAndFireChangeEvents() error {
 	r.apartmentStatusMu.Lock()
 	oldStatus := r.apartmentStatus
 	r.apartmentStatus = newStatus
-	// Invoke callbacks outside the lock so they may safely subscribe or unsubscribe.
-	callbacks := maps.Clone(r.apartmentStatusChangeCallbacks)
+	// Snapshot callbacks so user code runs without holding the registry lock.
+	callbacks := make([]ApartmentStatusChangeCallback, 0, len(r.apartmentStatusChangeCallbacks))
+	for _, callback := range r.apartmentStatusChangeCallbacks {
+		callbacks = append(callbacks, callback)
+	}
 	r.apartmentStatusMu.Unlock()
 
 	for _, callback := range callbacks {

--- a/pkg/digitalstrom/registry.go
+++ b/pkg/digitalstrom/registry.go
@@ -146,9 +146,25 @@ func (r *registry) GetOutputValuesOfDevice(deviceId string) ([]OutputValue, erro
 }
 
 func (r *registry) GetFunctionBlockForDevice(deviceId string) (FunctionBlock, error) {
-	device, err := r.GetDevice(deviceId)
+	functionBlocks, err := r.GetFunctionBlocksForDevice(deviceId)
 	if err != nil {
 		return FunctionBlock{}, err
+	}
+
+	length := len(functionBlocks)
+	if length == 0 {
+		return FunctionBlock{}, errors.New("No function block found for device " + deviceId)
+	}
+	if length > 1 {
+		return FunctionBlock{}, errors.New("Multiple function blocks found for device " + deviceId)
+	}
+	return functionBlocks[0], nil
+}
+
+func (r *registry) GetFunctionBlocksForDevice(deviceId string) ([]FunctionBlock, error) {
+	device, err := r.GetDevice(deviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	var functionBlocks []FunctionBlock
@@ -161,14 +177,7 @@ func (r *registry) GetFunctionBlockForDevice(deviceId string) (FunctionBlock, er
 		}
 	}
 
-	length := len(functionBlocks)
-	if length == 0 {
-		return FunctionBlock{}, errors.New("Multiple function blocks found for device " + deviceId)
-	}
-	if length > 1 {
-		return FunctionBlock{}, errors.New("No function block found for device " + deviceId)
-	}
-	return functionBlocks[0], nil
+	return functionBlocks, nil
 }
 
 func (r *registry) GetControllers() ([]Controller, error) {

--- a/pkg/digitalstrom/registry.go
+++ b/pkg/digitalstrom/registry.go
@@ -2,8 +2,10 @@ package digitalstrom
 
 import (
 	"errors"
-	"github.com/rs/zerolog/log"
+	"maps"
 	"sync"
+
+	"github.com/rs/zerolog/log"
 )
 
 type DeviceChangeCallback func(deviceId string, outputId string, oldValue float64, newValue float64)
@@ -288,10 +290,8 @@ func (r *registry) updateApartmentStatusAndFireChangeEvents() error {
 	r.apartmentStatusMu.Lock()
 	oldStatus := r.apartmentStatus
 	r.apartmentStatus = newStatus
-	callbacks := make([]ApartmentStatusChangeCallback, 0, len(r.apartmentStatusChangeCallbacks))
-	for _, callback := range r.apartmentStatusChangeCallbacks {
-		callbacks = append(callbacks, callback)
-	}
+	// Invoke callbacks outside the lock so they may safely subscribe or unsubscribe.
+	callbacks := maps.Clone(r.apartmentStatusChangeCallbacks)
 	r.apartmentStatusMu.Unlock()
 
 	for _, callback := range callbacks {

--- a/pkg/digitalstrom/registry.go
+++ b/pkg/digitalstrom/registry.go
@@ -7,6 +7,7 @@ import (
 )
 
 type DeviceChangeCallback func(deviceId string, outputId string, oldValue float64, newValue float64)
+type ApartmentStatusChangeCallback func(oldStatus *ApartmentStatus, newStatus *ApartmentStatus)
 
 // Registry The registry hold the current structure of the appartement and the latest known state
 type Registry interface {
@@ -26,9 +27,12 @@ type Registry interface {
 	GetControllers() ([]Controller, error)
 	GetControllerById(controllerId string) (Controller, error)
 	GetMeterings() ([]Metering, error)
+	GetApartmentStatus() (*ApartmentStatus, error)
 
 	DeviceChangeSubscribe(deviceId string, callback DeviceChangeCallback) error
 	DeviceChangeUnsubscribe(deviceId string) error
+	ApartmentStatusChangeSubscribe(id string, callback ApartmentStatusChangeCallback) error
+	ApartmentStatusChangeUnsubscribe(id string) error
 }
 
 type registry struct {
@@ -43,15 +47,18 @@ type registry struct {
 	submoduleLookup      map[string]Submodule
 	functionBlocksLookup map[string]FunctionBlock
 
-	deviceChangeCallbacks map[string]DeviceChangeCallback
+	deviceChangeCallbacks          map[string]DeviceChangeCallback
+	apartmentStatusChangeCallbacks map[string]ApartmentStatusChangeCallback
 
-	registryLoading sync.Mutex
+	registryLoading   sync.Mutex
+	apartmentStatusMu sync.RWMutex
 }
 
 func NewRegistry(digitalstromClient Client) Registry {
 	return &registry{
-		digitalstromClient:    digitalstromClient,
-		deviceChangeCallbacks: make(map[string]DeviceChangeCallback),
+		digitalstromClient:             digitalstromClient,
+		deviceChangeCallbacks:          make(map[string]DeviceChangeCallback),
+		apartmentStatusChangeCallbacks: make(map[string]ApartmentStatusChangeCallback),
 	}
 }
 
@@ -115,8 +122,15 @@ func (r *registry) GetOutputsOfDevice(deviceId string) ([]Output, error) {
 }
 
 func (r *registry) GetOutputValuesOfDevice(deviceId string) ([]OutputValue, error) {
+	r.apartmentStatusMu.RLock()
+	apartmentStatus := r.apartmentStatus
+	r.apartmentStatusMu.RUnlock()
+	if apartmentStatus == nil {
+		return nil, errors.New("Apartment status is not loaded")
+	}
+
 	outputs := []OutputValue{}
-	for _, device := range r.apartmentStatus.Included.Devices {
+	for _, device := range apartmentStatus.Included.Devices {
 		if device.DeviceId == deviceId {
 			for _, functionBlockValue := range device.Attributes.FunctionBlocks {
 				for _, outputValue := range functionBlockValue.Outputs {
@@ -169,6 +183,15 @@ func (r *registry) GetControllerById(controllerId string) (Controller, error) {
 
 func (r *registry) GetMeterings() ([]Metering, error) {
 	return r.meterings.Meterings, nil
+}
+
+func (r *registry) GetApartmentStatus() (*ApartmentStatus, error) {
+	r.apartmentStatusMu.RLock()
+	defer r.apartmentStatusMu.RUnlock()
+	if r.apartmentStatus == nil {
+		return nil, errors.New("Apartment status is not loaded")
+	}
+	return r.apartmentStatus, nil
 }
 
 func (r *registry) updateApartment() error {
@@ -236,13 +259,44 @@ func (r *registry) DeviceChangeUnsubscribe(deviceId string) error {
 	return nil
 }
 
+func (r *registry) ApartmentStatusChangeSubscribe(id string, callback ApartmentStatusChangeCallback) error {
+	r.apartmentStatusMu.Lock()
+	defer r.apartmentStatusMu.Unlock()
+	if _, exists := r.apartmentStatusChangeCallbacks[id]; exists {
+		return errors.New("Apartment status callback with id " + id + " already exists")
+	}
+	r.apartmentStatusChangeCallbacks[id] = callback
+	return nil
+}
+
+func (r *registry) ApartmentStatusChangeUnsubscribe(id string) error {
+	r.apartmentStatusMu.Lock()
+	defer r.apartmentStatusMu.Unlock()
+	if _, exists := r.apartmentStatusChangeCallbacks[id]; !exists {
+		return errors.New("No apartment status callback with id " + id + " exists")
+	}
+	delete(r.apartmentStatusChangeCallbacks, id)
+	return nil
+}
+
 func (r *registry) updateApartmentStatusAndFireChangeEvents() error {
-	oldStatus := r.apartmentStatus
 	newStatus, err := r.digitalstromClient.GetApartmentStatus()
 	if err != nil {
 		return err
 	}
+
+	r.apartmentStatusMu.Lock()
+	oldStatus := r.apartmentStatus
 	r.apartmentStatus = newStatus
+	callbacks := make([]ApartmentStatusChangeCallback, 0, len(r.apartmentStatusChangeCallbacks))
+	for _, callback := range r.apartmentStatusChangeCallbacks {
+		callbacks = append(callbacks, callback)
+	}
+	r.apartmentStatusMu.Unlock()
+
+	for _, callback := range callbacks {
+		callback(oldStatus, newStatus)
+	}
 
 	if oldStatus != nil {
 		// Check diff and broadcast events

--- a/pkg/digitalstrom/registry_test.go
+++ b/pkg/digitalstrom/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 )
 
 type apartmentStatusClientStub struct {
@@ -79,23 +80,41 @@ func TestRegistryApartmentStatusCallbackCanUnsubscribe(t *testing.T) {
 		apartmentStatus:                status,
 	}
 
-	called := false
+	callbackCalls := 0
 	var unsubscribeErr error
 	if err := registry.ApartmentStatusChangeSubscribe("test", func(*ApartmentStatus, *ApartmentStatus) {
-		called = true
+		callbackCalls++
 		unsubscribeErr = registry.ApartmentStatusChangeUnsubscribe("test")
 	}); err != nil {
 		t.Fatalf("expected callback subscription: %v", err)
 	}
 
-	if err := registry.updateApartmentStatusAndFireChangeEvents(); err != nil {
-		t.Fatalf("expected status update: %v", err)
+	updateDone := make(chan error, 1)
+	go func() {
+		updateDone <- registry.updateApartmentStatusAndFireChangeEvents()
+	}()
+
+	select {
+	case err := <-updateDone:
+		if err != nil {
+			t.Fatalf("expected status update: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("status update deadlocked while callback unsubscribed itself")
 	}
-	if !called {
-		t.Fatal("expected apartment status callback")
-	}
+
 	if unsubscribeErr != nil {
 		t.Fatalf("expected callback to unsubscribe itself: %v", unsubscribeErr)
+	}
+	if callbackCalls != 1 {
+		t.Fatalf("expected callback once, got %d calls", callbackCalls)
+	}
+
+	if err := registry.updateApartmentStatusAndFireChangeEvents(); err != nil {
+		t.Fatalf("expected second status update: %v", err)
+	}
+	if callbackCalls != 1 {
+		t.Fatalf("expected unsubscribed callback to remain at one call, got %d", callbackCalls)
 	}
 }
 

--- a/pkg/digitalstrom/registry_test.go
+++ b/pkg/digitalstrom/registry_test.go
@@ -70,6 +70,35 @@ func TestRegistryPublishesApartmentStatusChanges(t *testing.T) {
 	}
 }
 
+func TestRegistryApartmentStatusCallbackCanUnsubscribe(t *testing.T) {
+	status := &ApartmentStatus{}
+	registry := &registry{
+		digitalstromClient:             &constantApartmentStatusClientStub{status: status},
+		deviceChangeCallbacks:          map[string]DeviceChangeCallback{},
+		apartmentStatusChangeCallbacks: map[string]ApartmentStatusChangeCallback{},
+		apartmentStatus:                status,
+	}
+
+	called := false
+	var unsubscribeErr error
+	if err := registry.ApartmentStatusChangeSubscribe("test", func(*ApartmentStatus, *ApartmentStatus) {
+		called = true
+		unsubscribeErr = registry.ApartmentStatusChangeUnsubscribe("test")
+	}); err != nil {
+		t.Fatalf("expected callback subscription: %v", err)
+	}
+
+	if err := registry.updateApartmentStatusAndFireChangeEvents(); err != nil {
+		t.Fatalf("expected status update: %v", err)
+	}
+	if !called {
+		t.Fatal("expected apartment status callback")
+	}
+	if unsubscribeErr != nil {
+		t.Fatalf("expected callback to unsubscribe itself: %v", unsubscribeErr)
+	}
+}
+
 func TestRegistryApartmentStatusCallbacksAreConcurrentSafe(t *testing.T) {
 	status := &ApartmentStatus{}
 	registry := &registry{

--- a/pkg/digitalstrom/registry_test.go
+++ b/pkg/digitalstrom/registry_test.go
@@ -1,0 +1,122 @@
+package digitalstrom
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+type apartmentStatusClientStub struct {
+	Client
+	statuses []*ApartmentStatus
+}
+
+type constantApartmentStatusClientStub struct {
+	Client
+	status *ApartmentStatus
+}
+
+func (c *constantApartmentStatusClientStub) GetApartmentStatus() (*ApartmentStatus, error) {
+	return c.status, nil
+}
+
+func (c *apartmentStatusClientStub) GetApartmentStatus() (*ApartmentStatus, error) {
+	status := c.statuses[0]
+	c.statuses = c.statuses[1:]
+	return status, nil
+}
+
+func TestRegistryPublishesApartmentStatusChanges(t *testing.T) {
+	oldTemperature := 20.0
+	newTemperature := 21.0
+	client := &apartmentStatusClientStub{statuses: []*ApartmentStatus{
+		{Attributes: ApartmentStatusAttributes{Measurements: ApartmentMeasurements{Temperature: &oldTemperature}}},
+		{Attributes: ApartmentStatusAttributes{Measurements: ApartmentMeasurements{Temperature: &newTemperature}}},
+	}}
+	registry := &registry{
+		digitalstromClient:             client,
+		deviceChangeCallbacks:          map[string]DeviceChangeCallback{},
+		apartmentStatusChangeCallbacks: map[string]ApartmentStatusChangeCallback{},
+	}
+
+	if err := registry.updateApartmentStatusAndFireChangeEvents(); err != nil {
+		t.Fatalf("expected initial status update: %v", err)
+	}
+	var callbackOld *ApartmentStatus
+	var callbackNew *ApartmentStatus
+	if err := registry.ApartmentStatusChangeSubscribe("test", func(oldStatus *ApartmentStatus, newStatus *ApartmentStatus) {
+		callbackOld = oldStatus
+		callbackNew = newStatus
+	}); err != nil {
+		t.Fatalf("expected callback subscription: %v", err)
+	}
+	if err := registry.updateApartmentStatusAndFireChangeEvents(); err != nil {
+		t.Fatalf("expected second status update: %v", err)
+	}
+
+	if callbackOld == nil || callbackNew == nil {
+		t.Fatal("expected apartment status callback")
+	}
+	assertFloatPointer(t, "old temperature", callbackOld.Attributes.Measurements.Temperature, oldTemperature)
+	assertFloatPointer(t, "new temperature", callbackNew.Attributes.Measurements.Temperature, newTemperature)
+	current, err := registry.GetApartmentStatus()
+	if err != nil {
+		t.Fatalf("expected current status: %v", err)
+	}
+	assertFloatPointer(t, "current temperature", current.Attributes.Measurements.Temperature, newTemperature)
+
+	if err := registry.ApartmentStatusChangeUnsubscribe("test"); err != nil {
+		t.Fatalf("expected callback unsubscribe: %v", err)
+	}
+}
+
+func TestRegistryApartmentStatusCallbacksAreConcurrentSafe(t *testing.T) {
+	status := &ApartmentStatus{}
+	registry := &registry{
+		digitalstromClient:             &constantApartmentStatusClientStub{status: status},
+		deviceChangeCallbacks:          map[string]DeviceChangeCallback{},
+		apartmentStatusChangeCallbacks: map[string]ApartmentStatusChangeCallback{},
+		apartmentStatus:                status,
+	}
+
+	start := make(chan struct{})
+	errors := make(chan error, 2)
+	var workers sync.WaitGroup
+	workers.Add(2)
+	go func() {
+		defer workers.Done()
+		<-start
+		for i := 0; i < 1000; i++ {
+			id := fmt.Sprintf("subscriber-%d", i)
+			if err := registry.ApartmentStatusChangeSubscribe(id, func(*ApartmentStatus, *ApartmentStatus) {}); err != nil {
+				errors <- err
+				return
+			}
+			if err := registry.ApartmentStatusChangeUnsubscribe(id); err != nil {
+				errors <- err
+				return
+			}
+		}
+	}()
+	go func() {
+		defer workers.Done()
+		<-start
+		for i := 0; i < 1000; i++ {
+			if err := registry.updateApartmentStatusAndFireChangeEvents(); err != nil {
+				errors <- err
+				return
+			}
+			if _, err := registry.GetApartmentStatus(); err != nil {
+				errors <- err
+				return
+			}
+		}
+	}()
+
+	close(start)
+	workers.Wait()
+	close(errors)
+	for err := range errors {
+		t.Fatalf("concurrent apartment status access failed: %v", err)
+	}
+}

--- a/pkg/digitalstrom/registry_test.go
+++ b/pkg/digitalstrom/registry_test.go
@@ -99,6 +99,69 @@ func TestRegistryApartmentStatusCallbackCanUnsubscribe(t *testing.T) {
 	}
 }
 
+func TestRegistryReturnsAllFunctionBlocksForDevice(t *testing.T) {
+	registry := &registry{
+		devicesLookup: map[string]Device{
+			"device-1": {
+				DeviceId:   "device-1",
+				Attributes: DeviceAttributes{Submodules: []string{"submodule-1", "submodule-2"}},
+			},
+		},
+		submoduleLookup: map[string]Submodule{
+			"submodule-1": {Attributes: SubmoduleAttributes{FunctionBlocks: []string{"function-block-1"}}},
+			"submodule-2": {Attributes: SubmoduleAttributes{FunctionBlocks: []string{"function-block-2"}}},
+		},
+		functionBlocksLookup: map[string]FunctionBlock{
+			"function-block-1": {FunctionBlockId: "function-block-1"},
+			"function-block-2": {FunctionBlockId: "function-block-2"},
+		},
+	}
+
+	functionBlocks, err := registry.GetFunctionBlocksForDevice("device-1")
+	if err != nil {
+		t.Fatalf("expected function blocks: %v", err)
+	}
+	if len(functionBlocks) != 2 {
+		t.Fatalf("expected two function blocks, got %#v", functionBlocks)
+	}
+	if functionBlocks[0].FunctionBlockId != "function-block-1" || functionBlocks[1].FunctionBlockId != "function-block-2" {
+		t.Fatalf("unexpected function blocks: %#v", functionBlocks)
+	}
+}
+
+func TestRegistrySingleFunctionBlockErrorsDescribeCardinality(t *testing.T) {
+	tests := []struct {
+		name           string
+		functionBlocks []string
+		expected       string
+	}{
+		{name: "none", expected: "No function block found for device device-1"},
+		{name: "multiple", functionBlocks: []string{"function-block-1", "function-block-2"}, expected: "Multiple function blocks found for device device-1"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			registry := &registry{
+				devicesLookup: map[string]Device{
+					"device-1": {DeviceId: "device-1", Attributes: DeviceAttributes{Submodules: []string{"submodule-1"}}},
+				},
+				submoduleLookup: map[string]Submodule{
+					"submodule-1": {Attributes: SubmoduleAttributes{FunctionBlocks: test.functionBlocks}},
+				},
+				functionBlocksLookup: map[string]FunctionBlock{
+					"function-block-1": {FunctionBlockId: "function-block-1"},
+					"function-block-2": {FunctionBlockId: "function-block-2"},
+				},
+			}
+
+			_, err := registry.GetFunctionBlockForDevice("device-1")
+			if err == nil || err.Error() != test.expected {
+				t.Fatalf("expected %q, got %v", test.expected, err)
+			}
+		})
+	}
+}
+
 func TestRegistryApartmentStatusCallbacksAreConcurrentSafe(t *testing.T) {
 	status := &ApartmentStatus{}
 	registry := &registry{


### PR DESCRIPTION
## Summary

- add automatic discovery for dS-Weather stations
- publish temperature, illuminance, 10-minute average wind speed, wind gust and rain over MQTT
- add Home Assistant MQTT discovery for all five values
- document the new MQTT topics and tested hardware

## Implementation

The weather station is identified by the `Weather` function block technical name, so discovery does not depend on a user-defined device name.

Runtime values come from the cached `/api/v1/apartment/status` registry state:

- `attributes.measurements.temperature`
- `attributes.measurements.brightness`
- `attributes.measurements.windSpeed`
- `attributes.measurements.windGust`
- `attributes.weather.rain`

The module subscribes to apartment status changes through the existing registry and notification path. It does not add a separate polling ticker and does not use the old JSON API.

Home Assistant receives four measurement sensors and one rain binary sensor, grouped under the detected dS-Weather device. All five discovery entries are created even if the initial status response temporarily omits individual values; only values present in a status response are published.

The change is additive. Existing configuration and MQTT topics remain unchanged.

## Validation

- `go test -count=1 -timeout 2m ./...`
- `go test -race -count=1 -timeout 3m ./...`
- `go vet ./...`
- `go build ./...`
- field-tested with a dS Ready Theben weather station on dSS 1.19.12
- all five Home Assistant entities were available, and an illuminance update was observed through the notification and registry path