### PR TITLE
Restore per-device cover stop support

### DIFF
--- a/pkg/controller/modules/devices.go
+++ b/pkg/controller/modules/devices.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	devices string = "devices"
-	stop    string = "stop"
+	devices            string = "devices"
+	stop               string = "stop"
+	deviceStopActionID        = "std.stop"
 )
 
 // Device Module encapsulates all the logic regarding the devices. The logic
@@ -113,7 +114,28 @@ func (c *DeviceModule) onMqttMessage(deviceId string, outputId string, message s
 		return err
 	}
 
-	value, err := strconv.ParseFloat(strings.TrimSpace(message), 64)
+	trimmedMessage := strings.TrimSpace(message)
+	if strings.EqualFold(trimmedMessage, "STOP") {
+		functionBlock, err := c.dsRegistry.GetFunctionBlockForDevice(deviceId)
+		if err != nil {
+			return fmt.Errorf("no function block found for device %s: %w", deviceId, err)
+		}
+		if functionBlock.DeviceType() != digitalstrom.DeviceTypeBlind {
+			return fmt.Errorf("STOP payload is only valid for blind devices")
+		}
+		scenarioInvoker, ok := c.dsClient.(digitalstrom.ScenarioInvoker)
+		if !ok {
+			return fmt.Errorf("digitalstrom client does not support scenario invocation")
+		}
+		log.Info().
+			Str("device", device.Attributes.Name).
+			Str("deviceId", device.DeviceId).
+			Str("zone", device.Attributes.Zone).
+			Msg("Stopping blind device.")
+		return scenarioInvoker.InvokeScenarioByID(fmt.Sprintf("device-%s-%s", deviceId, deviceStopActionID))
+	}
+
+	value, err := strconv.ParseFloat(trimmedMessage, 64)
 	if err != nil {
 		return fmt.Errorf("error parsing message as float value: %w", err)
 	}

--- a/pkg/controller/modules/devices.go
+++ b/pkg/controller/modules/devices.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	devices            string = "devices"
-	stop               string = "stop"
+	mqttStopCommand           = "STOP"
 	deviceStopActionID        = "std.stop"
 )
 
@@ -115,30 +115,45 @@ func (c *DeviceModule) onMqttMessage(deviceId string, outputId string, message s
 	}
 
 	trimmedMessage := strings.TrimSpace(message)
-	if strings.EqualFold(trimmedMessage, "STOP") {
-		functionBlock, err := c.dsRegistry.GetFunctionBlockForDevice(deviceId)
+	if strings.EqualFold(trimmedMessage, mqttStopCommand) {
+		err = c.handleStopCommand(device)
+	} else {
+		var value float64
+		value, err = strconv.ParseFloat(trimmedMessage, 64)
 		if err != nil {
-			return fmt.Errorf("no function block found for device %s: %w", deviceId, err)
+			return fmt.Errorf("error parsing message as float value: %w", err)
 		}
-		if functionBlock.DeviceType() != digitalstrom.DeviceTypeBlind {
-			return fmt.Errorf("STOP payload is only valid for blind devices")
-		}
-		scenarioInvoker, ok := c.dsClient.(digitalstrom.ScenarioInvoker)
-		if !ok {
-			return fmt.Errorf("digitalstrom client does not support scenario invocation")
-		}
-		log.Info().
-			Str("device", device.Attributes.Name).
-			Str("deviceId", device.DeviceId).
-			Str("zone", device.Attributes.Zone).
-			Msg("Stopping blind device.")
-		return scenarioInvoker.InvokeScenarioByID(fmt.Sprintf("device-%s-%s", deviceId, deviceStopActionID))
+		err = c.handleNumericCommand(device, outputId, value)
 	}
+	return err
+}
 
-	value, err := strconv.ParseFloat(trimmedMessage, 64)
+func (c *DeviceModule) handleStopCommand(device digitalstrom.Device) error {
+	functionBlock, err := c.dsRegistry.GetFunctionBlockForDevice(device.DeviceId)
 	if err != nil {
-		return fmt.Errorf("error parsing message as float value: %w", err)
+		return fmt.Errorf("no function block found for device %s: %w", device.DeviceId, err)
 	}
+	if functionBlock.DeviceType() != digitalstrom.DeviceTypeBlind {
+		return fmt.Errorf("%s payload is only valid for blind devices", mqttStopCommand)
+	}
+	stopScenarioID, ok := deviceStopScenarioID(device)
+	if !ok {
+		return fmt.Errorf("device %s does not advertise a %s scenario", device.DeviceId, deviceStopActionID)
+	}
+	scenarioInvoker, ok := c.dsClient.(digitalstrom.ScenarioInvoker)
+	if !ok {
+		return fmt.Errorf("digitalstrom client does not support scenario invocation")
+	}
+	log.Info().
+		Str("device", device.Attributes.Name).
+		Str("deviceId", device.DeviceId).
+		Str("zone", device.Attributes.Zone).
+		Str("scenarioId", stopScenarioID).
+		Msg("Stopping blind device.")
+	return scenarioInvoker.InvokeScenarioByID(stopScenarioID)
+}
+
+func (c *DeviceModule) handleNumericCommand(device digitalstrom.Device, outputId string, value float64) error {
 	value = c.invertValueIfNeeded(outputId, value)
 	log.Info().
 		Str("device", device.Attributes.Name).
@@ -146,12 +161,12 @@ func (c *DeviceModule) onMqttMessage(deviceId string, outputId string, message s
 		Float64("value", value).
 		Msg("Setting value.")
 
-	functionBlock, err := c.dsRegistry.GetFunctionBlockForDevice(deviceId)
+	functionBlock, err := c.dsRegistry.GetFunctionBlockForDevice(device.DeviceId)
 	if err != nil {
-		return fmt.Errorf("no function block found for device %s: %w", deviceId, err)
+		return fmt.Errorf("no function block found for device %s: %w", device.DeviceId, err)
 	}
 
-	err = c.dsClient.DeviceSetOutputValue(deviceId, functionBlock.FunctionBlockId, outputId, value)
+	err = c.dsClient.DeviceSetOutputValue(device.DeviceId, functionBlock.FunctionBlockId, outputId, value)
 	if err != nil {
 		return err
 	}
@@ -162,6 +177,21 @@ func (c *DeviceModule) onMqttMessage(deviceId string, outputId string, message s
 	}
 
 	return nil
+}
+
+func deviceStopScenarioID(device digitalstrom.Device) (string, bool) {
+	suffix := "-" + deviceStopActionID
+	for _, scenarioID := range device.Attributes.Scenarios {
+		if strings.HasSuffix(scenarioID, suffix) {
+			return scenarioID, true
+		}
+	}
+	return "", false
+}
+
+func (c *DeviceModule) supportsScenarioInvocation() bool {
+	_, ok := c.dsClient.(digitalstrom.ScenarioInvoker)
+	return ok
 }
 
 func (c *DeviceModule) updateDevice(deviceId string) error {
@@ -313,7 +343,6 @@ func (c *DeviceModule) GetHomeAssistantEntities() ([]homeassistant.DiscoveryConf
 					c.deviceCommandTopic(device.Attributes.Name, properties.PositionChannel)),
 				PayloadOpen:  "100.00",
 				PayloadClose: "0.00",
-				PayloadStop:  "STOP",
 				StateTopic: c.mqttClient.GetFullTopic(
 					c.deviceStateTopic(device.Attributes.Name, properties.PositionChannel)),
 				StateOpen:        "100.00",
@@ -321,6 +350,21 @@ func (c *DeviceModule) GetHomeAssistantEntities() ([]homeassistant.DiscoveryConf
 				PositionTopic:    c.mqttClient.GetFullTopic(c.deviceStateTopic(device.Attributes.Name, properties.PositionChannel)),
 				SetPositionTopic: c.mqttClient.GetFullTopic(c.deviceCommandTopic(device.Attributes.Name, properties.PositionChannel)),
 				PositionTemplate: "{{ value | int }}",
+			}
+			if !c.supportsScenarioInvocation() {
+				log.Warn().
+					Str("device", device.Attributes.Name).
+					Str("deviceId", device.DeviceId).
+					Str("zone", device.Attributes.Zone).
+					Msg("Digitalstrom client does not support scenario invocation; omitting Home Assistant stop command.")
+			} else if _, ok := deviceStopScenarioID(device); ok {
+				entityConfig.PayloadStop = mqttStopCommand
+			} else {
+				log.Warn().
+					Str("device", device.Attributes.Name).
+					Str("deviceId", device.DeviceId).
+					Str("zone", device.Attributes.Zone).
+					Msg("Blind device does not advertise a stop scenario; omitting Home Assistant stop command.")
 			}
 			if properties.TiltChannel != "" {
 				entityConfig.TiltStatusTemplate = "{{ value | int }}"

--- a/pkg/controller/modules/devices_test.go
+++ b/pkg/controller/modules/devices_test.go
@@ -1,0 +1,280 @@
+package modules
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/gaetancollaud/digitalstrom-mqtt/pkg/digitalstrom"
+	"github.com/gaetancollaud/digitalstrom-mqtt/pkg/homeassistant"
+	"github.com/gaetancollaud/digitalstrom-mqtt/pkg/mqtt"
+)
+
+type deviceMQTTClientStub struct {
+	mqtt.Client
+	prefix string
+}
+
+func (c *deviceMQTTClientStub) Publish(string, interface{}) error {
+	return nil
+}
+
+func (c *deviceMQTTClientStub) GetFullTopic(topic string) string {
+	return path.Join(c.prefix, topic)
+}
+
+type deviceSetOutputCall struct {
+	deviceID        string
+	functionBlockID string
+	outputID        string
+	value           float64
+}
+
+type deviceDigitalstromClientStub struct {
+	digitalstrom.Client
+	setOutputCalls []deviceSetOutputCall
+	scenarioIDs    []string
+	scenarioError  error
+}
+
+func (c *deviceDigitalstromClientStub) DeviceSetOutputValue(deviceID string, functionBlockID string, outputID string, value float64) error {
+	c.setOutputCalls = append(c.setOutputCalls, deviceSetOutputCall{
+		deviceID:        deviceID,
+		functionBlockID: functionBlockID,
+		outputID:        outputID,
+		value:           value,
+	})
+	return nil
+}
+
+func (c *deviceDigitalstromClientStub) InvokeScenarioByID(scenarioID string) error {
+	c.scenarioIDs = append(c.scenarioIDs, scenarioID)
+	return c.scenarioError
+}
+
+type deviceRegistryStub struct {
+	digitalstrom.Registry
+	devices        map[string]digitalstrom.Device
+	functionBlocks map[string]digitalstrom.FunctionBlock
+}
+
+func (r *deviceRegistryStub) GetDevices() ([]digitalstrom.Device, error) {
+	devices := make([]digitalstrom.Device, 0, len(r.devices))
+	for _, device := range r.devices {
+		devices = append(devices, device)
+	}
+	return devices, nil
+}
+
+func (r *deviceRegistryStub) GetDevice(deviceID string) (digitalstrom.Device, error) {
+	device, ok := r.devices[deviceID]
+	if !ok {
+		return digitalstrom.Device{}, fmt.Errorf("device %s not found", deviceID)
+	}
+	return device, nil
+}
+
+func (r *deviceRegistryStub) GetFunctionBlockForDevice(deviceID string) (digitalstrom.FunctionBlock, error) {
+	functionBlock, ok := r.functionBlocks[deviceID]
+	if !ok {
+		return digitalstrom.FunctionBlock{}, fmt.Errorf("function block for device %s not found", deviceID)
+	}
+	return functionBlock, nil
+}
+
+func (r *deviceRegistryStub) GetOutputsOfDevice(deviceID string) ([]digitalstrom.Output, error) {
+	functionBlock, err := r.GetFunctionBlockForDevice(deviceID)
+	if err != nil {
+		return nil, err
+	}
+	return functionBlock.Attributes.Outputs, nil
+}
+
+func TestDeviceModuleInvokesPerDeviceStopScenarioForBlind(t *testing.T) {
+	dsClient := &deviceDigitalstromClientStub{}
+	module := testDeviceModule(dsClient, "blind-1", "Office Blind", testBlindFunctionBlock())
+
+	err := module.onMqttMessage("blind-1", "shadePositionOutside", " STOP ")
+
+	if err != nil {
+		t.Fatalf("expected blind STOP payload to invoke device action, got error: %v", err)
+	}
+	if len(dsClient.setOutputCalls) != 0 {
+		t.Fatalf("expected no output writes for STOP payload, got %d", len(dsClient.setOutputCalls))
+	}
+	if len(dsClient.scenarioIDs) != 1 {
+		t.Fatalf("expected one device scenario, got %d", len(dsClient.scenarioIDs))
+	}
+	if dsClient.scenarioIDs[0] != "device-blind-1-std.stop" {
+		t.Fatalf("unexpected device scenario ID: %q", dsClient.scenarioIDs[0])
+	}
+}
+
+func TestDeviceModuleReturnsStopScenarioError(t *testing.T) {
+	expectedError := errors.New("device action failed")
+	dsClient := &deviceDigitalstromClientStub{scenarioError: expectedError}
+	module := testDeviceModule(dsClient, "blind-1", "Office Blind", testBlindFunctionBlock())
+
+	err := module.onMqttMessage("blind-1", "shadePositionOutside", "STOP")
+
+	if !errors.Is(err, expectedError) {
+		t.Fatalf("expected scenario error, got %v", err)
+	}
+	if len(dsClient.scenarioIDs) != 1 {
+		t.Fatalf("expected one scenario invocation, got %d", len(dsClient.scenarioIDs))
+	}
+}
+
+func TestDeviceModuleReturnsErrorWhenClientCannotInvokeScenarios(t *testing.T) {
+	dsClient := &deviceClientWithoutScenarioStub{}
+	module := testDeviceModule(dsClient, "blind-1", "Office Blind", testBlindFunctionBlock())
+
+	err := module.onMqttMessage("blind-1", "shadePositionOutside", "STOP")
+
+	if err == nil || !strings.Contains(err.Error(), "does not support scenario invocation") {
+		t.Fatalf("expected unsupported scenario error, got %v", err)
+	}
+}
+
+func TestDeviceModuleRejectsStopPayloadForNonBlind(t *testing.T) {
+	dsClient := &deviceDigitalstromClientStub{}
+	module := testDeviceModule(dsClient, "light-1", "Office Light", testLightFunctionBlock())
+
+	err := module.onMqttMessage("light-1", "brightness", "stop")
+
+	if err == nil {
+		t.Fatal("expected STOP payload on non-blind device to fail")
+	}
+	if len(dsClient.setOutputCalls) != 0 {
+		t.Fatalf("expected no output writes for invalid STOP payload, got %d", len(dsClient.setOutputCalls))
+	}
+	if len(dsClient.scenarioIDs) != 0 {
+		t.Fatalf("expected no device scenario for invalid STOP payload, got %d", len(dsClient.scenarioIDs))
+	}
+}
+
+func TestDeviceModuleStillWritesNumericOutputValues(t *testing.T) {
+	dsClient := &deviceDigitalstromClientStub{}
+	module := testDeviceModule(dsClient, "blind-1", "Office Blind", testBlindFunctionBlock())
+
+	err := module.onMqttMessage("blind-1", "shadePositionOutside", "42.50")
+
+	if err != nil {
+		t.Fatalf("expected numeric payload to be written, got error: %v", err)
+	}
+	if len(dsClient.scenarioIDs) != 0 {
+		t.Fatalf("expected no scenario for numeric payload, got %d", len(dsClient.scenarioIDs))
+	}
+	if len(dsClient.setOutputCalls) != 1 {
+		t.Fatalf("expected one output write, got %d", len(dsClient.setOutputCalls))
+	}
+	call := dsClient.setOutputCalls[0]
+	if call.deviceID != "blind-1" || call.functionBlockID != "fb-blind-1" || call.outputID != "shadePositionOutside" || call.value != 42.50 {
+		t.Fatalf("unexpected output write: %#v", call)
+	}
+}
+
+func TestDeviceModuleCoverDiscoveryAdvertisesStopCommand(t *testing.T) {
+	dsClient := &deviceDigitalstromClientStub{}
+	module := testDeviceModule(dsClient, "blind-1", "Office Blind", testBlindFunctionBlock())
+
+	configs, err := module.GetHomeAssistantEntities()
+
+	if err != nil {
+		t.Fatalf("expected discovery config, got error: %v", err)
+	}
+	if len(configs) != 1 || configs[0].Domain != homeassistant.Cover {
+		t.Fatalf("expected one cover discovery config, got %#v", configs)
+	}
+	coverConfig, ok := configs[0].Config.(*homeassistant.CoverConfig)
+	if !ok {
+		t.Fatalf("expected cover config, got %T", configs[0].Config)
+	}
+	if coverConfig.PayloadStop != "STOP" {
+		t.Fatalf("expected payload_stop STOP, got %q", coverConfig.PayloadStop)
+	}
+	expectedTopic := "digitalstrom/devices/Office Blind/shadePositionOutside/command"
+	if coverConfig.CommandTopic != expectedTopic {
+		t.Fatalf("expected stop command topic %q, got %q", expectedTopic, coverConfig.CommandTopic)
+	}
+	payload, err := json.Marshal(coverConfig)
+	if err != nil {
+		t.Fatalf("marshal cover discovery config: %v", err)
+	}
+	var discoveryPayload map[string]interface{}
+	if err := json.Unmarshal(payload, &discoveryPayload); err != nil {
+		t.Fatalf("decode cover discovery config: %v", err)
+	}
+	if discoveryPayload["payload_stop"] != "STOP" {
+		t.Fatalf("expected serialized payload_stop STOP, got %#v", discoveryPayload["payload_stop"])
+	}
+	if discoveryPayload["command_topic"] != expectedTopic {
+		t.Fatalf("expected serialized command_topic %q, got %#v", expectedTopic, discoveryPayload["command_topic"])
+	}
+}
+
+type deviceClientWithoutScenarioStub struct {
+	digitalstrom.Client
+}
+
+func (c *deviceClientWithoutScenarioStub) DeviceSetOutputValue(string, string, string, float64) error {
+	return nil
+}
+
+func testDeviceModule(dsClient digitalstrom.Client, deviceID string, name string, functionBlock digitalstrom.FunctionBlock) *DeviceModule {
+	return &DeviceModule{
+		dsClient:   dsClient,
+		mqttClient: &deviceMQTTClientStub{prefix: "digitalstrom"},
+		dsRegistry: &deviceRegistryStub{
+			devices: map[string]digitalstrom.Device{
+				deviceID: {
+					DeviceId: deviceID,
+					Attributes: digitalstrom.DeviceAttributes{
+						Name: name,
+						Zone: "9",
+					},
+				},
+			},
+			functionBlocks: map[string]digitalstrom.FunctionBlock{
+				deviceID: functionBlock,
+			},
+		},
+	}
+}
+
+func testBlindFunctionBlock() digitalstrom.FunctionBlock {
+	return digitalstrom.FunctionBlock{
+		FunctionBlockId: "fb-blind-1",
+		Attributes: digitalstrom.FunctionBlockAttributes{
+			TechnicalName: "GR-KL200",
+			Outputs: []digitalstrom.Output{
+				{
+					OutputId: "shadePositionOutside",
+					Attributes: digitalstrom.OutputAttributes{
+						Mode: digitalstrom.OutputModePositional,
+					},
+				},
+			},
+		},
+	}
+}
+
+func testLightFunctionBlock() digitalstrom.FunctionBlock {
+	return digitalstrom.FunctionBlock{
+		FunctionBlockId: "fb-light-1",
+		Attributes: digitalstrom.FunctionBlockAttributes{
+			TechnicalName: "GE-KM200",
+			Outputs: []digitalstrom.Output{
+				{
+					OutputId: "brightness",
+					Attributes: digitalstrom.OutputAttributes{
+						Mode: digitalstrom.OutputModeGradual,
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/controller/modules/devices_test.go
+++ b/pkg/controller/modules/devices_test.go
@@ -93,23 +93,27 @@ func (r *deviceRegistryStub) GetOutputsOfDevice(deviceID string) ([]digitalstrom
 	return functionBlock.Attributes.Outputs, nil
 }
 
-func TestDeviceModuleInvokesPerDeviceStopScenarioForBlind(t *testing.T) {
-	dsClient := &deviceDigitalstromClientStub{}
-	module := testDeviceModule(dsClient, "blind-1", "Office Blind", testBlindFunctionBlock())
+func TestDeviceModuleInvokesAdvertisedStopScenarioCaseInsensitively(t *testing.T) {
+	for _, payload := range []string{" STOP ", "stop"} {
+		t.Run(payload, func(t *testing.T) {
+			dsClient := &deviceDigitalstromClientStub{}
+			module := testDeviceModule(dsClient, "blind-1", "Office Blind", testBlindFunctionBlock())
 
-	err := module.onMqttMessage("blind-1", "shadePositionOutside", " STOP ")
+			err := module.onMqttMessage("blind-1", "shadePositionOutside", payload)
 
-	if err != nil {
-		t.Fatalf("expected blind STOP payload to invoke device action, got error: %v", err)
-	}
-	if len(dsClient.setOutputCalls) != 0 {
-		t.Fatalf("expected no output writes for STOP payload, got %d", len(dsClient.setOutputCalls))
-	}
-	if len(dsClient.scenarioIDs) != 1 {
-		t.Fatalf("expected one device scenario, got %d", len(dsClient.scenarioIDs))
-	}
-	if dsClient.scenarioIDs[0] != "device-blind-1-std.stop" {
-		t.Fatalf("unexpected device scenario ID: %q", dsClient.scenarioIDs[0])
+			if err != nil {
+				t.Fatalf("expected blind stop payload to invoke device action, got error: %v", err)
+			}
+			if len(dsClient.setOutputCalls) != 0 {
+				t.Fatalf("expected no output writes for stop payload, got %d", len(dsClient.setOutputCalls))
+			}
+			if len(dsClient.scenarioIDs) != 1 {
+				t.Fatalf("expected one device scenario, got %d", len(dsClient.scenarioIDs))
+			}
+			if dsClient.scenarioIDs[0] != "advertised-blind-stop-std.stop" {
+				t.Fatalf("unexpected device scenario ID: %q", dsClient.scenarioIDs[0])
+			}
+		})
 	}
 }
 
@@ -136,6 +140,24 @@ func TestDeviceModuleReturnsErrorWhenClientCannotInvokeScenarios(t *testing.T) {
 
 	if err == nil || !strings.Contains(err.Error(), "does not support scenario invocation") {
 		t.Fatalf("expected unsupported scenario error, got %v", err)
+	}
+}
+
+func TestDeviceModuleRejectsStopWhenDeviceDoesNotAdvertiseScenario(t *testing.T) {
+	dsClient := &deviceDigitalstromClientStub{}
+	module := testDeviceModule(dsClient, "blind-1", "Office Blind", testBlindFunctionBlock())
+	registry := module.dsRegistry.(*deviceRegistryStub)
+	device := registry.devices["blind-1"]
+	device.Attributes.Scenarios = nil
+	registry.devices["blind-1"] = device
+
+	err := module.onMqttMessage("blind-1", "shadePositionOutside", "STOP")
+
+	if err == nil || !strings.Contains(err.Error(), "does not advertise") {
+		t.Fatalf("expected missing stop scenario error, got %v", err)
+	}
+	if len(dsClient.scenarioIDs) != 0 {
+		t.Fatalf("expected no scenario invocation, got %d", len(dsClient.scenarioIDs))
 	}
 }
 
@@ -193,8 +215,8 @@ func TestDeviceModuleCoverDiscoveryAdvertisesStopCommand(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected cover config, got %T", configs[0].Config)
 	}
-	if coverConfig.PayloadStop != "STOP" {
-		t.Fatalf("expected payload_stop STOP, got %q", coverConfig.PayloadStop)
+	if coverConfig.PayloadStop != mqttStopCommand {
+		t.Fatalf("expected payload_stop %s, got %q", mqttStopCommand, coverConfig.PayloadStop)
 	}
 	expectedTopic := "digitalstrom/devices/Office Blind/shadePositionOutside/command"
 	if coverConfig.CommandTopic != expectedTopic {
@@ -208,11 +230,71 @@ func TestDeviceModuleCoverDiscoveryAdvertisesStopCommand(t *testing.T) {
 	if err := json.Unmarshal(payload, &discoveryPayload); err != nil {
 		t.Fatalf("decode cover discovery config: %v", err)
 	}
-	if discoveryPayload["payload_stop"] != "STOP" {
-		t.Fatalf("expected serialized payload_stop STOP, got %#v", discoveryPayload["payload_stop"])
+	if discoveryPayload["payload_stop"] != mqttStopCommand {
+		t.Fatalf("expected serialized payload_stop %s, got %#v", mqttStopCommand, discoveryPayload["payload_stop"])
 	}
 	if discoveryPayload["command_topic"] != expectedTopic {
 		t.Fatalf("expected serialized command_topic %q, got %#v", expectedTopic, discoveryPayload["command_topic"])
+	}
+}
+
+func TestDeviceModuleCoverDiscoveryOmitsStopWithoutAdvertisedScenario(t *testing.T) {
+	module := testDeviceModule(&deviceDigitalstromClientStub{}, "blind-1", "Office Blind", testBlindFunctionBlock())
+	registry := module.dsRegistry.(*deviceRegistryStub)
+	device := registry.devices["blind-1"]
+	device.Attributes.Scenarios = nil
+	registry.devices["blind-1"] = device
+
+	configs, err := module.GetHomeAssistantEntities()
+
+	if err != nil {
+		t.Fatalf("expected discovery config, got error: %v", err)
+	}
+	coverConfig, ok := configs[0].Config.(*homeassistant.CoverConfig)
+	if !ok {
+		t.Fatalf("expected cover config, got %T", configs[0].Config)
+	}
+	if coverConfig.PayloadStop != "" {
+		t.Fatalf("expected no payload_stop without advertised scenario, got %q", coverConfig.PayloadStop)
+	}
+	payload, err := json.Marshal(coverConfig)
+	if err != nil {
+		t.Fatalf("marshal cover discovery config: %v", err)
+	}
+	var discoveryPayload map[string]interface{}
+	if err := json.Unmarshal(payload, &discoveryPayload); err != nil {
+		t.Fatalf("decode cover discovery config: %v", err)
+	}
+	if _, found := discoveryPayload["payload_stop"]; found {
+		t.Fatalf("expected serialized discovery to omit payload_stop: %#v", discoveryPayload)
+	}
+}
+
+func TestDeviceModuleCoverDiscoveryOmitsStopWhenClientCannotInvokeScenarios(t *testing.T) {
+	module := testDeviceModule(&deviceClientWithoutScenarioStub{}, "blind-1", "Office Blind", testBlindFunctionBlock())
+
+	configs, err := module.GetHomeAssistantEntities()
+
+	if err != nil {
+		t.Fatalf("expected discovery config, got error: %v", err)
+	}
+	coverConfig, ok := configs[0].Config.(*homeassistant.CoverConfig)
+	if !ok {
+		t.Fatalf("expected cover config, got %T", configs[0].Config)
+	}
+	if coverConfig.PayloadStop != "" {
+		t.Fatalf("expected no payload_stop without scenario invocation support, got %q", coverConfig.PayloadStop)
+	}
+	payload, err := json.Marshal(coverConfig)
+	if err != nil {
+		t.Fatalf("marshal cover discovery config: %v", err)
+	}
+	var discoveryPayload map[string]interface{}
+	if err := json.Unmarshal(payload, &discoveryPayload); err != nil {
+		t.Fatalf("decode cover discovery config: %v", err)
+	}
+	if _, found := discoveryPayload["payload_stop"]; found {
+		t.Fatalf("expected serialized discovery to omit payload_stop: %#v", discoveryPayload)
 	}
 }
 
@@ -225,6 +307,10 @@ func (c *deviceClientWithoutScenarioStub) DeviceSetOutputValue(string, string, s
 }
 
 func testDeviceModule(dsClient digitalstrom.Client, deviceID string, name string, functionBlock digitalstrom.FunctionBlock) *DeviceModule {
+	scenarios := []string{}
+	if functionBlock.DeviceType() == digitalstrom.DeviceTypeBlind {
+		scenarios = append(scenarios, "advertised-blind-stop-std.stop")
+	}
 	return &DeviceModule{
 		dsClient:   dsClient,
 		mqttClient: &deviceMQTTClientStub{prefix: "digitalstrom"},
@@ -233,8 +319,9 @@ func testDeviceModule(dsClient digitalstrom.Client, deviceID string, name string
 				deviceID: {
 					DeviceId: deviceID,
 					Attributes: digitalstrom.DeviceAttributes{
-						Name: name,
-						Zone: "9",
+						Name:      name,
+						Zone:      "9",
+						Scenarios: scenarios,
 					},
 				},
 			},

--- a/pkg/digitalstrom/client.go
+++ b/pkg/digitalstrom/client.go
@@ -43,6 +43,11 @@ type Client interface {
 	NotificationUnsubscribe(id string) error
 }
 
+// ScenarioInvoker is implemented by clients that can invoke a scenario resource directly.
+type ScenarioInvoker interface {
+	InvokeScenarioByID(scenarioID string) error
+}
+
 // client implements the DigitalStrom interface.
 // Clients are safe for concurrent use by multiple goroutines.
 type client struct {
@@ -181,6 +186,11 @@ func (c *client) DeviceSetOutputValue(deviceId string, functionBlockId string, o
 	return c.patchRequest(path, contents)
 }
 
+func (c *client) InvokeScenarioByID(scenarioID string) error {
+	path := fmt.Sprintf("api/v1/apartment/scenarios/%s/invoke", url.PathEscape(scenarioID))
+	return c.postRequest(path, struct{}{})
+}
+
 func (c *client) NotificationSubscribe(id string, callback NotificationCallback) error {
 	_, exists := c.notificationCallbacks[id]
 	if exists {
@@ -248,6 +258,11 @@ func (c *client) doRequest(method string, path string, params url.Values, body i
 
 func (c *client) patchRequest(path string, body interface{}) error {
 	_, err := c.doRequest(http.MethodPatch, path, nil, body)
+	return err
+}
+
+func (c *client) postRequest(path string, body interface{}) error {
+	_, err := c.doRequest(http.MethodPost, path, nil, body)
 	return err
 }
 

--- a/pkg/digitalstrom/client_test.go
+++ b/pkg/digitalstrom/client_test.go
@@ -9,6 +9,73 @@ import (
 	"testing"
 )
 
+func TestGetApartmentDecodesDeviceScenariosWithoutAdditionalInclude(t *testing.T) {
+	var method string
+	var requestPath string
+	var include string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		method = request.Method
+		requestPath = request.URL.Path
+		include = request.URL.Query().Get("include")
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{
+			"data": {
+				"id": "apartment-1",
+				"included": {
+					"dsDevices": [{
+						"id": "blind-1",
+						"attributes": {
+							"name": "Office Blind",
+							"scenarios": ["device-blind-1-std.stop"]
+						}
+					}]
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	port, err := strconv.Atoi(serverURL.Port())
+	if err != nil {
+		t.Fatalf("parse test server port: %v", err)
+	}
+	client := &client{
+		httpClient: server.Client(),
+		options: ClientOptions{
+			Host:   serverURL.Hostname(),
+			Port:   port,
+			ApiKey: "test-api-key",
+		},
+	}
+
+	apartment, err := client.GetApartment()
+
+	if err != nil {
+		t.Fatalf("get apartment: %v", err)
+	}
+	if method != http.MethodGet {
+		t.Fatalf("expected GET, got %s", method)
+	}
+	if requestPath != "/api/v1/apartment" {
+		t.Fatalf("unexpected request path: %s", requestPath)
+	}
+	expectedInclude := "installation,dsDevices,submodules,functionBlocks,zones,controllers,meterings"
+	if include != expectedInclude {
+		t.Fatalf("expected include query %q, got %q", expectedInclude, include)
+	}
+	if len(apartment.Included.Devices) != 1 {
+		t.Fatalf("expected one decoded device, got %d", len(apartment.Included.Devices))
+	}
+	scenarios := apartment.Included.Devices[0].Attributes.Scenarios
+	if len(scenarios) != 1 || scenarios[0] != "device-blind-1-std.stop" {
+		t.Fatalf("unexpected decoded scenarios: %#v", scenarios)
+	}
+}
+
 func TestInvokeScenarioByIDPostsToScenarioResource(t *testing.T) {
 	var method string
 	var requestPath string

--- a/pkg/digitalstrom/client_test.go
+++ b/pkg/digitalstrom/client_test.go
@@ -1,0 +1,62 @@
+package digitalstrom
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+)
+
+func TestInvokeScenarioByIDPostsToScenarioResource(t *testing.T) {
+	var method string
+	var requestPath string
+	var authorization string
+	var requestBody map[string]interface{}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		method = request.Method
+		requestPath = request.URL.Path
+		authorization = request.Header.Get("Authorization")
+		if err := json.NewDecoder(request.Body).Decode(&requestBody); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	port, err := strconv.Atoi(serverURL.Port())
+	if err != nil {
+		t.Fatalf("parse test server port: %v", err)
+	}
+	client := &client{
+		httpClient: server.Client(),
+		options: ClientOptions{
+			Host:   serverURL.Hostname(),
+			Port:   port,
+			ApiKey: "test-api-key",
+		},
+	}
+
+	err = client.InvokeScenarioByID("device-blind-1-std.stop")
+
+	if err != nil {
+		t.Fatalf("invoke scenario by ID: %v", err)
+	}
+	if method != http.MethodPost {
+		t.Fatalf("expected POST, got %s", method)
+	}
+	if requestPath != "/api/v1/apartment/scenarios/device-blind-1-std.stop/invoke" {
+		t.Fatalf("unexpected request path: %s", requestPath)
+	}
+	if authorization != "Bearer test-api-key" {
+		t.Fatalf("unexpected authorization header: %s", authorization)
+	}
+	if len(requestBody) != 0 {
+		t.Fatalf("expected empty request body, got %#v", requestBody)
+	}
+}


### PR DESCRIPTION
## Summary

- handle the Home Assistant `STOP` payload for cover devices
- invoke the modern per-device `device-<dSUID>-std.stop` scenario
- keep existing numeric position commands unchanged
- add regression coverage for the MQTT command, Home Assistant discovery, and API request

## Background

Home Assistant discovery already advertises `payload_stop: "STOP"`, but the device module currently parses every command payload as a numeric output value. As a result, the stop button fails after migrating to version 2.x.

The modern API exposes a device-specific stop scenario at:

`/api/v1/apartment/scenarios/device-<dSUID>-std.stop/invoke`

This keeps the command scoped to the selected cover and does not require the deprecated API, a zone action, or a configuration change.

I verified the behavior against a real dSS installation: while two covers were moving, stopping one cover left the other one running.

Related to #51.

## Testing

- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- live Home Assistant and dSS test with two independently moving covers